### PR TITLE
Bring RKE2 docs up to date with new CIS 1.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ It is a fully [conformant Kubernetes distribution](https://landscape.cncf.io/sel
 
 To meet these goals, RKE2 does the following:
 
-- Provides [defaults and configuration options](security/hardening_guide.md) that allow clusters to pass the CIS Kubernetes Benchmark [v1.5](security/cis_self_assessment15.md) or [v1.6](security/cis_self_assessment16.md) with minimal operator intervention
+- Provides [defaults and configuration options](security/hardening_guide.md) that allow clusters to pass the CIS Kubernetes Benchmark [v1.6](security/cis_self_assessment16.md) or [v1.23](security/cis_self_assessment123.md) with minimal operator intervention
 - Enables [FIPS 140-2 compliance](security/fips_support.md)
 - Regularly scans components for CVEs using [trivy](https://github.com/aquasecurity/trivy) in our build pipeline
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -115,3 +115,26 @@ Please install iptables or xtables-nft package to resolve this problem
 failed to allocate for range 0: no IP addresses available in range set
 ```
 There are two ways to resolve this. You can either manually remove unused IPs from that directory or drain the node, run rke2-killall.sh, start the rke2 systemd service and uncordon the node. If you need to undertake any of these actions, please report the problem via GitHub, making sure to specify how it was triggered.
+
+## Ingress in CIS Mode
+
+By default, when RKE2 is run with a CIS profile selected by the `profile` parameter, it applies network policies that can be restrictive for ingress. This, coupled with the `rke2-ingress-nginx` chart having `hostNetwork: false` by default, requires users to set network policies of their own to allow access to the ingress URLs. Below is an example networkpolicy that allows ingress to any workload in the namespace it is applied in. See https://kubernetes.io/docs/concepts/services-networking/network-policies/ for more configuration options.
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-to-backends
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: rke2-ingress-nginx
+  policyTypes:
+  - Ingress
+```
+For more information, refer to comments on https://github.com/rancher/rke2/issues/3195.

--- a/docs/reference/linux_agent_config.md
+++ b/docs/reference/linux_agent_config.md
@@ -51,7 +51,7 @@ OPTIONS:
    --kubelet-path value                          (experimental/agent) Override kubelet binary path [$RKE2_KUBELET_PATH]
    --cloud-provider-name value                   (cloud provider) Cloud provider name [$RKE2_CLOUD_PROVIDER_NAME]
    --cloud-provider-config value                 (cloud provider) Cloud provider configuration file path [$RKE2_CLOUD_PROVIDER_CONFIG]
-   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.5, cis-1.6 ) [$RKE2_CIS_PROFILE]
+   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.6, cis-1.23 ) [$RKE2_CIS_PROFILE]
    --audit-policy-file value                     (security) Path to the file that defines the audit policy configuration [$RKE2_AUDIT_POLICY_FILE]
    --control-plane-resource-requests value       (components) Control Plane resource requests [$RKE2_CONTROL_PLANE_RESOURCE_REQUESTS]
    --control-plane-resource-limits value         (components) Control Plane resource limits [$RKE2_CONTROL_PLANE_RESOURCE_LIMITS]

--- a/docs/reference/server_config.md
+++ b/docs/reference/server_config.md
@@ -87,7 +87,7 @@ OPTIONS:
    --kubelet-path value                          (experimental/agent) Override kubelet binary path [$RKE2_KUBELET_PATH]
    --cloud-provider-name value                   (cloud provider) Cloud provider name [$RKE2_CLOUD_PROVIDER_NAME]
    --cloud-provider-config value                 (cloud provider) Cloud provider configuration file path [$RKE2_CLOUD_PROVIDER_CONFIG]
-   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.5, cis-1.6 ) [$RKE2_CIS_PROFILE]
+   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.6, cis-1.23 ) [$RKE2_CIS_PROFILE]
    --audit-policy-file value                     (security) Path to the file that defines the audit policy configuration [$RKE2_AUDIT_POLICY_FILE]
    --control-plane-resource-requests value       (components) Control Plane resource requests [$RKE2_CONTROL_PLANE_RESOURCE_REQUESTS]
    --control-plane-resource-limits value         (components) Control Plane resource limits [$RKE2_CONTROL_PLANE_RESOURCE_LIMITS]

--- a/docs/reference/windows_agent_config.md
+++ b/docs/reference/windows_agent_config.md
@@ -52,7 +52,7 @@ ill also be used for the apiserver client load-balancer. (default: 6444) [%RKE2_
    --kubelet-path value                          (experimental/agent) Override kubelet binary path [%RKE2_KUBELET_PATH%]
    --cloud-provider-name value                   (cloud provider) Cloud provider name [%RKE2_CLOUD_PROVIDER_NAME%]
    --cloud-provider-config value                 (cloud provider) Cloud provider configuration file path [%RKE2_CLOUD_PROVIDER_CONFIG%]
-   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.5, cis-1.6 ) [%RKE2_CIS_PROFILE%]
+   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.6, cis-1.23 ) [%RKE2_CIS_PROFILE%]
    --audit-policy-file value                     (security) Path to the file that defines the audit policy configuration [%RKE2_AUDIT_POLICY_FILE%]
    --control-plane-resource-requests value       (components) Control Plane resource requests [%RKE2_CONTROL_PLANE_RESOURCE_REQUESTS%]
    --control-plane-resource-limits value         (components) Control Plane resource limits [%RKE2_CONTROL_PLANE_RESOURCE_LIMITS%]

--- a/docs/security/cis_self_assessment123.md
+++ b/docs/security/cis_self_assessment123.md
@@ -2271,7 +2271,7 @@ A container running in the host's IPC namespace can use IPC to interact with pro
 
 There should be at least one admission control policy defined which does not permit containers to share the host IPC namespace.
 
-If you need to run containers which require hostIPC, this should be definited in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+If you need to run containers which require hostIPC, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
 </details>
 
 **Result:** Pass

--- a/docs/security/cis_self_assessment123.md
+++ b/docs/security/cis_self_assessment123.md
@@ -1,16 +1,16 @@
 ---
-title: CIS 1.5 Self-Assessment Guide
+title: CIS 1.23 Self-Assessment Guide
 ---
 
-### CIS Kubernetes Benchmark v1.5 - RKE2 v1.18
+### CIS Kubernetes Benchmark v1.23 - RKE2
 
 #### Overview
 
 This document is a companion to the RKE2 security hardening guide. The hardening guide provides prescriptive guidance for hardening a production installation of RKE2, and this benchmark guide is meant to help you evaluate the level of security of the hardened cluster against each control in the CIS Kubernetes benchmark. It is to be used by RKE2 operators, security teams, auditors, and decision makers.
 
-This guide is specific to the **v1.18** release line of RKE2 and the **v1.5.1** release of the CIS Kubernetes Benchmark.
+This guide is specific to the **v1.25** release line of RKE2 and the **v1.23** release of the CIS Kubernetes Benchmark.
 
-For more detail about each control, including more detailed descriptions and remediations for failing tests, you can refer to the corresponding section of the CIS Kubernetes Benchmark v1.5. You can download the benchmark after logging in to [CISecurity.org]( https://www.cisecurity.org/benchmark/kubernetes/).
+For more details about each control, including detailed descriptions and remediations for failing tests, you can refer to the corresponding section of the CIS Kubernetes Benchmark v1.23 You can download the benchmark after logging in to [CISecurity.org](https://www.cisecurity.org/benchmark/kubernetes/).
 
 #### Testing controls methodology
 
@@ -22,7 +22,7 @@ These are the possible results for each control:
 
 - **Pass** - The RKE2 cluster under test passed the audit outlined in the benchmark.
 - **Not Applicable** - The control is not applicable to RKE2 because of how it is designed to operate. The remediation section will explain why this is so.
-- **Not Scored - Operator Dependent** - The control is not scored in the CIS benchmark and it depends on the cluster's use case or some other factor that must be determined by the cluster operator. These controls have been evaluated to ensure RKE2 does not prevent their implementation, but no further configuration or auditing of the cluster under test has been performed.
+- **Manual - Operator Dependent** - The control is Manual in the CIS benchmark and it depends on the cluster's use case or some other factor that must be determined by the cluster operator. These controls have been evaluated to ensure RKE2 does not prevent their implementation, but no further configuration or auditing of the cluster under test has been performed.
 
 ### Controls
 
@@ -32,7 +32,7 @@ These are the possible results for each control:
 
 
 #### 1.1.1
-Ensure that the API server pod specification file permissions are set to `644` or more restrictive (Scored)
+Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The API server pod specification file controls various parameters that set the behavior of the API server. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -51,7 +51,7 @@ By default, RKE2 creates these files with `644` permissions. No manual remediati
 
 
 #### 1.1.2
-Ensure that the API server pod specification file ownership is set to `root:root` (Scored)
+Ensure that the API server pod specification file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The API server pod specification file controls various parameters that set the behavior of the API server. You should set its file ownership to maintain the integrity of the file. The file should be owned by `root:root`.
@@ -70,7 +70,7 @@ By default, RKE2 creates these files with `root:root` ownership. No manual remed
 
 
 #### 1.1.3
-Ensure that the controller manager pod specification file permissions are set to `644` or more restrictive (Scored)
+Ensure that the controller manager pod specification file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The controller manager pod specification file controls various parameters that set the behavior of the Controller Manager on the master node. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -89,7 +89,7 @@ By default, RKE2 creates these files with `644` permissions. No manual remediati
 
 
 #### 1.1.4
-Ensure that the controller manager pod specification file ownership is set to `root:root` (Scored)
+Ensure that the controller manager pod specification file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The controller manager pod specification file controls various parameters that set the behavior of various components of the master node. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.
@@ -108,7 +108,7 @@ By default, RKE2 creates these files with `root:root` ownership. No manual remed
 
 
 #### 1.1.5
-Ensure that the scheduler pod specification file permissions are set to `644` or more restrictive (Scored)
+Ensure that the scheduler pod specification file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The scheduler pod specification file controls various parameters that set the behavior of the Scheduler service in the master node. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -127,7 +127,7 @@ By default, RKE2 creates these files with `644` permissions. No manual remediati
 
 
 #### 1.1.6
-Ensure that the scheduler pod specification file ownership is set to `root:root` (Scored)
+Ensure that the scheduler pod specification file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The scheduler pod specification file controls various parameters that set the behavior of the kube-scheduler service in the master node. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.
@@ -146,7 +146,7 @@ By default, RKE2 creates these files with `root:root` ownership. No manual remed
 
 
 #### 1.1.7
-Ensure that the etcd pod specification file permissions are set to `644` or more restrictive (Scored)
+Ensure that the etcd pod specification file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The etcd pod specification file /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml controls various parameters that set the behavior of the etcd service in the master node. etcd is a highly-available key-value store which Kubernetes uses for persistent storage of all of its REST API object. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -165,7 +165,7 @@ By default, RKE2 creates these files with `644` permissions. No manual remediati
 
 
 #### 1.1.8
-Ensure that the etcd pod specification file ownership is set to `root:root` (Scored)
+Ensure that the etcd pod specification file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The etcd pod specification file /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml controls various parameters that set the behavior of the etcd service in the master node. etcd is a highly-available key-value store which Kubernetes uses for persistent storage of all of its REST API object. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.
@@ -184,7 +184,7 @@ By default, RKE2 creates these files with `root:root` ownership. No manual remed
 
 
 #### 1.1.9
-Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Not Scored)
+Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)
 <details>
 <summary>Rationale</summary>
 Container Network Interface provides various networking options for overlay networking. You should consult their documentation and restrict their respective file permissions to maintain the integrity of those files. Those files should be writable by only the administrators on the system.
@@ -203,7 +203,7 @@ RKE2 deploys the default CNI, Canal, using a Helm chart. The chart is defined as
 
 
 #### 1.1.10
-Ensure that the Container Network Interface file ownership is set to `root:root` (Not Scored)
+Ensure that the Container Network Interface file ownership is set to `root:root` (Manual)
 <details>
 <summary>Rationale</summary>
 Container Network Interface provides various networking options for overlay networking. You should consult their documentation and restrict their respective file permissions to maintain the integrity of those files. Those files should be owned by root:root.
@@ -222,7 +222,7 @@ RKE2 deploys the default CNI, Canal, using a Helm chart. The chart is defined as
 
 
 #### 1.1.11
-Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)
+Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. This data directory should be protected from any unauthorized reads or writes. It should not be readable or writable by any group members or the world.
@@ -241,7 +241,7 @@ RKE2 manages the etcd data directory and sets its permissions to 700. No manual 
 
 
 #### 1.1.12
-Ensure that the etcd data directory ownership is set to `etcd:etcd` (Scored)
+Ensure that the etcd data directory ownership is set to `etcd:etcd` (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. This data directory should be protected from any unauthorized reads or writes. It should be owned by etcd:etcd.
@@ -256,11 +256,11 @@ etcd:etcd
 ```
 
 **Remediation:**
-When running RKE2 with the `profile` flag set to `cis-1.5`, RKE2 will refuse to start if the `etcd` user and group doesn't exist on the host. If it does exist, RKE2 will automatically set the ownership of the etcd data directory to `etcd:etcd` and ensure the etcd static pod is started with that user and group.
+When running RKE2 with the `profile` flag set to `cis-1.23`, RKE2 will refuse to start if the `etcd` user and group doesn't exist on the host. If it does exist, RKE2 will automatically set the ownership of the etcd data directory to `etcd:etcd` and ensure the etcd static pod is started with that user and group.
 
 
 #### 1.1.13
-Ensure that the `admin.conf` file permissions are set to `644` or more restrictive (Scored)
+Ensure that the `admin.conf` file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The admin.conf is the administrator kubeconfig file defining various settings for the administration of the cluster. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -281,7 +281,7 @@ By default, RKE2 creates this file at `/var/lib/rancher/rke2/server/cred/admin.k
 
 
 #### 1.1.14
-Ensure that the admin.conf file ownership is set to `root:root` (Scored)
+Ensure that the admin.conf file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The admin.conf file contains the admin credentials for the cluster. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.
@@ -302,8 +302,8 @@ By default, RKE2 creates this file at `stat -c %U:%G /var/lib/rancher/rke2/serve
 
 
 #### 1.1.15
-Ensure that the `scheduler.conf` file permissions are set to `644` or more restrictive (Scored)
-<details>
+Ensure that the `scheduler.conf` file permissions are set to `644` or more restrictive (Automated)
+<details> 
 <summary>Rationale</summary>
 
 The scheduler.conf file is the kubeconfig file for the Scheduler. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -324,7 +324,7 @@ By default, RKE2 creates this file at `/var/lib/rancher/rke2/server/cred/schedul
 
 
 #### 1.1.16
-Ensure that the `scheduler.conf` file ownership is set to `root:root` (Scored)
+Ensure that the `scheduler.conf` file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The scheduler.conf file is the kubeconfig file for the Scheduler. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.
@@ -345,7 +345,7 @@ By default, RKE2 creates this file at `/var/lib/rancher/rke2/server/cred/schedul
 
 
 #### 1.1.17
-Ensure that the `controller.kubeconfig` file permissions are set to `644` or more restrictive (Scored)
+Ensure that the `controller.kubeconfig` file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The controller.kubeconfig file is the kubeconfig file for the Scheduler. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -365,7 +365,7 @@ stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig
 By default, RKE2 creates this file at `/var/lib/rancher/rke2/server/cred/controller.kubeconfig` and automatically sets its permissions to `644`. No manual remediation needed.
 
 #### 1.1.18
-Ensure that the `controller.kubeconfig` file ownership is set to `root:root` (Scored)
+Ensure that the `controller.kubeconfig` file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The controller.kubeconfig file is the kubeconfig file for the Scheduler. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.
@@ -385,7 +385,7 @@ root:root
 By default, RKE2 creates this file at `/var/lib/rancher/rke2/server/cred/controller.kubeconfig` and automatically sets its ownership to `root:root`.
 
 #### 1.1.19
-Ensure that the Kubernetes PKI directory and file ownership is set to `root:root` (Scored)
+Ensure that the Kubernetes PKI directory and file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 Kubernetes makes use of a number of certificates as part of its operation. You should set the ownership of the directory containing the PKI information and all files in that directory to maintain their integrity. The directory and files should be owned by root:root.
@@ -404,7 +404,7 @@ By default, RKE2 creates the directory and files with the expected ownership of 
 
 
 #### 1.1.20
-Ensure that the Kubernetes PKI certificate file permissions are set to `644` or more restrictive (Scored)
+Ensure that the Kubernetes PKI certificate file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 Kubernetes makes use of a number of certificate files as part of the operation of its components. The permissions on these files should be set to 644 or more restrictive to protect their integrity.
@@ -426,7 +426,7 @@ By default, RKE2 creates the files with the expected permissions of `644`. No ma
 
 
 #### 1.1.21
-Ensure that the Kubernetes PKI key file permissions are set to `600` (Scored)
+Ensure that the Kubernetes PKI key file permissions are set to `600` (Automated)
 <details>
 <summary>Rationale</summary>
 Kubernetes makes use of a number of key files as part of the operation of its components. The permissions on these files should be set to 600 to protect their integrity and confidentiality.
@@ -452,13 +452,13 @@ This section contains recommendations relating to API server configuration flags
 
 
 #### 1.2.1
-Ensure that the --anonymous-auth argument is set to false (Not Scored)
+Ensure that the --anonymous-auth argument is set to false (Manual)
 
 <details>
 <summary>Rationale</summary>
 When enabled, requests that are not rejected by other configured authentication methods are treated as anonymous requests. These requests are then served by the API server. You should rely on authentication to authorize access and disallow anonymous requests.
 
-If you are using RBAC authorization, it is generally considered reasonable to allow anonymous access to the API Server for health checks and discovery purposes, and hence this recommendation is not scored. However, you should consider whether anonymous discovery is an acceptable risk for your purposes.
+If you are using RBAC authorization, it is generally considered reasonable to allow anonymous access to the API Server for health checks and discovery purposes, and hence this recommendation is Manual. However, you should consider whether anonymous discovery is an acceptable risk for your purposes.
 </details>
 
 **Result:** Pass
@@ -476,30 +476,7 @@ Verify that `--anonymous-auth=false` is present.
 By default, RKE2 kube-apiserver is configured to run with this flag and value. No manual remediation is needed.
 
 #### 1.2.2
-Ensure that the `--basic-auth-file` argument is not set (Scored)
-<details>
-<summary>Rationale</summary>
-Basic authentication uses plaintext credentials for authentication. Currently, the basic authentication credentials last indefinitely, and the password cannot be changed without restarting the API server. The basic authentication is currently supported for convenience. Hence, basic authentication should not be used.
-</details>
-
-**Result:** Pass
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/bin/ps -ef | grep kube-apiserver | grep -v grep
-```
-
-Verify that the `--basic-auth-file` argument does not exist.
-
-**Remediation:**
-By default, RKE2 does not run with basic authentication enabled. No manual remediation is needed.
-
-
-#### 1.2.3
-Ensure that the `--token-auth-file` parameter is not set (Scored)
-
+Ensure that the --token-auth-file parameter is not set (Automated)
 <details>
 <summary>Rationale</summary>
 The token-based authentication utilizes static tokens to authenticate requests to the apiserver. The tokens are stored in clear-text in a file on the apiserver, and cannot be revoked or rotated without restarting the apiserver. Hence, do not use static token-based authentication.
@@ -517,10 +494,35 @@ Run the below command on the master node.
 Verify that the `--token-auth-file` argument does not exist.
 
 **Remediation:**
-By default, RKE2 does not run with basic authentication enabled. No manual remediation is needed.
+By default, RKE2 does not run with token authentication enabled. No manual remediation is needed.
+
+
+#### 1.2.3
+Ensure that the --DenyServiceExternalIPs is not set (Automated)
+
+<details>
+<summary>Rationale</summary>
+This admission controller rejects all net-new usage of the Service field externalIPs. This feature is very powerful (allows network traffic interception) and not well controlled by policy. When enabled, users of the cluster may not create new Services which use externalIPs and may not add new values to externalIPs on existing Service objects. Existing uses of externalIPs are not affected, and users may remove values from externalIPs on existing Service objects.
+
+Most users do not need this feature at all, and cluster admins should consider disabling it. Clusters that do need to use this feature should consider using some custom policy to manage usage of it.
+</details>
+
+**Result:** Pass
+
+**Audit:**
+Run the below command on the master node.
+
+```bash
+/bin/ps -ef | grep kube-apiserver | grep -v grep
+```
+
+Verify that the `--enable-admission-plugins` argument does not have `DenyServiceExternalIPs`.
+
+**Remediation:**
+By default, RKE2 does not set `DenyServiceExternalIPs` to the admission plugin flag. No manual remediation is needed.
 
 #### 1.2.4
-Ensure that the `--kubelet-https` argument is set to true (Scored)
+Ensure that the `--kubelet-https` argument is set to true (Automated)
 
 <details>
 <summary>Rationale</summary>
@@ -543,7 +545,7 @@ Verify that the `--kubelet-https` argument does not exist.
 By default, RKE2 kube-apiserver doesn't run with the `--kubelet-https` parameter as it runs with TLS. No manual remediation is needed.
 
 #### 1.2.5
-Ensure that the `--kubelet-client-certificate` and `--kubelet-client-key` arguments are set as appropriate (Scored)
+Ensure that the `--kubelet-client-certificate` and `--kubelet-client-key` arguments are set as appropriate (Automated)
 
 <details>
 <summary>Rationale</summary>
@@ -566,7 +568,7 @@ By default, RKE2 kube-apiserver is ran with these arguments for secure communica
 
 
 #### 1.2.6
-Ensure that the `--kubelet-certificate-authority` argument is set as appropriate (Scored)
+Ensure that the `--kubelet-certificate-authority` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 The connections from the apiserver to the kubelet are used for fetching logs for pods, attaching (through kubectl) to running pods, and using the kubelet’s port-forwarding functionality. These connections terminate at the kubelet’s HTTPS endpoint. By default, the apiserver does not verify the kubelet’s serving certificate, which makes the connection subject to man-in-the-middle attacks, and unsafe to run over untrusted and/or public networks.
@@ -588,7 +590,7 @@ By default, RKE2 kube-apiserver is ran with this argument for secure communicati
 
 
 #### 1.2.7
-Ensure that the `--authorization-mode` argument is not set to `AlwaysAllow` (Scored)
+Ensure that the `--authorization-mode` argument is not set to `AlwaysAllow` (Automated)
 <details>
 <summary>Rationale</summary>
 The API Server, can be configured to allow all requests. This mode should not be used on any production cluster.
@@ -610,7 +612,7 @@ By default, RKE2 sets `Node,RBAC` as the parameter to the `--authorization-mode`
 
 
 #### 1.2.8
-Ensure that the `--authorization-mode` argument includes `Node` (Scored)
+Ensure that the `--authorization-mode` argument includes `Node` (Automated)
 <details>
 <summary>Rationale</summary>
 The Node authorization mode only allows kubelets to read Secret, ConfigMap, PersistentVolume, and PersistentVolumeClaim objects associated with their nodes.
@@ -632,7 +634,7 @@ By default, RKE2 sets `Node,RBAC` as the parameter to the `--authorization-mode`
 
 
 #### 1.2.9
-Ensure that the `--authorization-mode` argument includes `RBAC` (Scored)
+Ensure that the `--authorization-mode` argument includes `RBAC` (Automated)
 <details>
 <summary>Rationale</summary>
 Role Based Access Control (RBAC) allows fine-grained control over the operations that different entities can perform on different objects in the cluster. It is recommended to use the RBAC authorization mode.
@@ -654,7 +656,7 @@ By default, RKE2 sets `Node,RBAC` as the parameter to the `--authorization-mode`
 
 
 #### 1.2.10
-Ensure that the admission control plugin EventRateLimit is set (Not Scored)
+Ensure that the admission control plugin EventRateLimit is set (Manual)
 <details>
 <summary>Rationale</summary>
 Using `EventRateLimit` admission control enforces a limit on the number of events that the API Server will accept in a given time slice. A misbehaving workload could overwhelm and DoS the API Server, making it unavailable. This particularly applies to a multi-tenant cluster, where there might be a small percentage of misbehaving tenants which could have a significant impact on the performance of the cluster overall. Hence, it is recommended to limit the rate of events that the API server will accept.
@@ -662,7 +664,7 @@ Using `EventRateLimit` admission control enforces a limit on the number of event
 Note: This is an Alpha feature in the Kubernetes 1.15 release.
 </details>
 
-**Result:** **Not Scored - Operator Dependent**
+**Result:** **Manual - Operator Dependent**
 
 **Audit:**
 Run the below command on the master node.
@@ -679,7 +681,7 @@ To configure this, follow the Kubernetes documentation and set the desired limit
 
 
 #### 1.2.11
-Ensure that the admission control plugin `AlwaysAdmit` is not set (Scored)
+Ensure that the admission control plugin `AlwaysAdmit` is not set (Automated)
 <details>
 <summary>Rationale</summary>
 Setting admission control plugin AlwaysAdmit allows all requests and do not filter any requests.
@@ -703,14 +705,14 @@ By default, RKE2 only sets `NodeRestriction,PodSecurityPolicy` as the parameter 
 
 
 #### 1.2.12
-Ensure that the admission control plugin AlwaysPullImages is set (Not Scored)
+Ensure that the admission control plugin AlwaysPullImages is set (Manual)
 <details>
 <summary>Rationale</summary>
 Setting admission control policy to `AlwaysPullImages` forces every new pod to pull the required images every time. In a multi-tenant cluster users can be assured that their private images can only be used by those who have the credentials to pull them. Without this admission control policy, once an image has been pulled to a node, any pod from any user can use it simply by knowing the image’s name, without any authorization check against the image ownership. When this plug-in is enabled, images are always pulled prior to starting containers, which means valid credentials are required.
 
 </details>
 
-**Result:** **Not Scored - Operator Dependent**
+**Result:** **Manual - Operator Dependent**
 
 **Audit:**
 Run the below command on the master node.
@@ -726,7 +728,7 @@ By default, RKE2 only sets `NodeRestriction,PodSecurityPolicy` as the parameter 
 To configure this, follow the Kubernetes documentation and set the desired limits in a configuration file. Then refer to RKE2's documentation to see how to supply additional api server configuration via the kube-apiserver-arg parameter.
 
 #### 1.2.13
-Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Not Scored)
+Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)
 <details>
 <summary>Rationale</summary>
 SecurityContextDeny can be used to provide a layer of security for clusters which do not have PodSecurityPolicies enabled.
@@ -748,7 +750,7 @@ By default, RKE2 automatically enables the `PodSecurityPolicy` admission plugin.
 
 
 #### 1.2.14
-Ensure that the admission control plugin `ServiceAccount` is set (Scored)
+Ensure that the admission control plugin `ServiceAccount` is set (Automated)
 <details>
 <summary>Rationale</summary>
 When you create a pod, if you do not specify a service account, it is automatically assigned the `default` service account in the same namespace. You should create your own service account and let the API server manage its security tokens.
@@ -771,7 +773,7 @@ By default, RKE2 does not use this argument. If there's a desire to use this arg
 
 
 #### 1.2.15
-Ensure that the admission control plugin `NamespaceLifecycle` is set (Scored)
+Ensure that the admission control plugin `NamespaceLifecycle` is set (Automated)
 <details>
 <summary>Rationale</summary>
 Setting admission control policy to `NamespaceLifecycle` ensures that objects cannot be created in non-existent namespaces, and that namespaces undergoing termination are not used for creating the new objects. This is recommended to enforce the integrity of the namespace termination process and also for the availability of the newer objects.
@@ -793,12 +795,10 @@ By default, RKE2 does not use this argument. No manual remediation needed.
 
 
 #### 1.2.16
-Ensure that the admission control plugin `PodSecurityPolicy` is set (Scored)
+Ensure that the admission control plugin NodeRestriction is set (Automated)
 <details>
 <summary>Rationale</summary>
-A Pod Security Policy is a cluster-level resource that controls the actions that a pod can perform and what it has the ability to access. The `PodSecurityPolicy` objects define a set of conditions that a pod must run with in order to be accepted into the system. Pod Security Policies are comprised of settings and strategies that control the security features a pod has access to and hence this must be used to control pod access permissions.
-
-**Note:** When the PodSecurityPolicy admission plugin is in use, there needs to be at least one PodSecurityPolicy in place for ANY pods to be admitted. See section 1.7 for recommendations on PodSecurityPolicy settings.
+Using the NodeRestriction plug-in ensures that the kubelet is restricted to the Node and Pod objects that it could modify as defined. Such kubelets will only be allowed to modify their own Node API object, and only modify Pod API objects that are bound to their node.
 </details>
 
 **Result:** Pass
@@ -810,79 +810,14 @@ Run the below command on the master node.
 /bin/ps -ef | grep kube-apiserver | grep -v grep
 ```
 
-Verify that the `--enable-admission-plugins` argument is set to a value that includes `PodSecurityPolicy`.
+Verify that the `--enable-admission-plugins` argument is set to a value that includes `NodeRestriction`.
 
 **Remediation:**
-By default, RKE2 only sets `NodeRestriction,PodSecurityPolicy` as the parameter to the `--enable-admission-plugins` argument. No manual remediation needed.
+By default, RKE2 only sets `NodeRestriction` as the parameter to the `--enable-admission-plugins` argument. No manual remediation needed.
 
 
 #### 1.2.17
-Ensure that the admission control plugin `NodeRestriction` is set (Scored)
-<details>
-<summary>Rationale</summary>
-Using the `NodeRestriction` plug-in ensures that the kubelet is restricted to the `Node` and `Pod` objects that it could modify as defined. Such kubelets will only be allowed to modify their own `Node` API object, and only modify `Pod` API objects that are bound to their node.
-
-</details>
-
-**Result:** Pass
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/bin/ps -ef | grep kube-apiserver | grep -v grep
-```
-
-**Remediation:**
-By default, RKE2 only sets `NodeRestriction,PodSecurityPolicy` as the parameter to the `--enable-admission-plugins` argument. No manual remediation needed.
-
-
-#### 1.2.18
-Ensure that the `--insecure-bind-address` argument is not set (Scored)
-<details>
-<summary>Rationale</summary>
-If you bind the apiserver to an insecure address, basically anyone who could connect to it over the insecure port, would have unauthenticated and unencrypted access to your master node. The apiserver doesn't do any authentication checking for insecure binds and traffic to the Insecure API port is not encrpyted, allowing attackers to potentially read sensitive data in transit.
-</details>
-
-**Result:** Pass
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/bin/ps -ef | grep kube-apiserver | grep -v grep
-```
-
-Verify that the `--insecure-bind-address` argument does not exist.
-
-**Remediation:**
-By default, RKE2 explicitly excludes the use of the `--insecure-bind-address` parameter. No manual remediation is needed.
-
-
-#### 1.2.19
-Ensure that the `--insecure-port` argument is set to `0` (Scored)
-<details>
-<summary>Rationale</summary>
-Setting up the apiserver to serve on an insecure port would allow unauthenticated and unencrypted access to your master node. This would allow attackers who could access this port, to easily take control of the cluster.
-</details>
-
-**Result:** Pass
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/bin/ps -ef | grep kube-apiserver | grep -v grep
-```
-
-Verify that the `--insecure-port` argument is set to 0.
-
-**Remediation:**
-By default, RKE2 starts the kube-apiserver process with this argument's parameter set to 0. No manual remediation is needed.
-
-
-#### 1.2.20
-Ensure that the `--secure-port` argument is not set to `0` (Scored)
+Ensure that the `--secure-port` argument is not set to `0` (Automated)
 <details>
 <summary>Rationale</summary>
 The secure port is used to serve https with authentication and authorization. If you disable it, no https traffic is served and all traffic is served unencrypted.
@@ -903,8 +838,8 @@ Verify that the `--secure-port` argument is either not set or is set to an integ
 By default, RKE2 sets the parameter of 6443 for the `--secure-port` argument. No manual remediation is needed.
 
 
-#### 1.2.21
-Ensure that the `--profiling` argument is set to `false` (Scored)
+#### 1.2.18
+Ensure that the `--profiling` argument is set to `false` (Automated)
 <details>
 <summary>Rationale</summary>
 Profiling allows for the identification of specific performance bottlenecks. It generates a significant amount of program data that could potentially be exploited to uncover system and program details. If you are not experiencing any bottlenecks and do not need the profiler for troubleshooting purposes, it is recommended to turn it off to reduce the potential attack surface.
@@ -925,8 +860,8 @@ Verify that the `--profiling` argument is set to false.
 By default, RKE2 sets the `--profiling` flag parameter to false. No manual remediation needed.
 
 
-#### 1.2.22
-Ensure that the `--audit-log-path` argument is set (Scored)
+#### 1.2.19
+Ensure that the `--audit-log-path` argument is set (Automated)
 <details>
 <summary>Rationale</summary>
 Auditing the Kubernetes API Server provides a security-relevant chronological set of records documenting the sequence of activities that have affected system by individual users, administrators or other components of the system. Even though currently, Kubernetes provides only basic audit capabilities, it should be enabled. You can enable it by setting an appropriate audit log path.
@@ -947,8 +882,8 @@ Verify that the `--audit-log-path` argument is set as appropriate.
 By default, RKE2 sets the `--audit-log-path` argument and parameter. No manual remediation needed.
 
 
-#### 1.2.23
-Ensure that the `--audit-log-maxage` argument is set to `30` or as appropriate (Scored)
+#### 1.2.20
+Ensure that the `--audit-log-maxage` argument is set to `30` or as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 Retaining logs for at least 30 days ensures that you can go back in time and investigate or correlate any events. Set your audit log retention period to 30 days or as per your business requirements.
@@ -969,8 +904,8 @@ Verify that the `--audit-log-maxage` argument is set to 30 or as appropriate.
 By default, RKE2 sets the `--audit-log-maxage` argument parameter to 30. No manual remediation needed.
 
 
-#### 1.2.24
-Ensure that the `--audit-log-maxbackup` argument is set to `10` or as appropriate (Scored)
+#### 1.2.21
+Ensure that the `--audit-log-maxbackup` argument is set to `10` or as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 Kubernetes automatically rotates the log files. Retaining old log files ensures that you would have sufficient log data available for carrying out any investigation or correlation. For example, if you have set file size of 100 MB and the number of old log files to keep as 10, you would approximate have 1 GB of log data that you could potentially use for your analysis.
@@ -991,8 +926,8 @@ Verify that the `--audit-log-maxbackup` argument is set to 10 or as appropriate.
 By default, RKE2 sets the `--audit-log-maxbackup` argument parameter to 10. No manual remediation needed.
 
 
-#### 1.2.25
-Ensure that the `--audit-log-maxsize` argument is set to `100` or as appropriate (Scored)
+#### 1.2.22
+Ensure that the `--audit-log-maxsize` argument is set to `100` or as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 Kubernetes automatically rotates the log files. Retaining old log files ensures that you would have sufficient log data available for carrying out any investigation or correlation. If you have set file size of 100 MB and the number of old log files to keep as 10, you would approximate have 1 GB of log data that you could potentially use for your analysis.
@@ -1013,8 +948,8 @@ Verify that the `--audit-log-maxsize` argument is set to 100 or as appropriate.
 By default, RKE2 sets the `--audit-log-maxsize` argument parameter to 100. No manual remediation needed.
 
 
-#### 1.2.26
-Ensure that the `--request-timeout` argument is set as appropriate (Scored)
+#### 1.2.23
+Ensure that the `--request-timeout` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 Setting global request timeout allows extending the API server request timeout limit to a duration appropriate to the user's connection speed. By default, it is set to 60 seconds which might be problematic on slower connections making cluster resources inaccessible once the data volume for requests exceeds what can be transmitted in 60 seconds. But, setting this timeout limit to be too large can exhaust the API server resources making it prone to Denial-of-Service attack. Hence, it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed.
@@ -1035,8 +970,8 @@ Verify that the `--request-timeout` argument is either not set or set to an appr
 By default, RKE2 does not set the `--request-timeout` argument. No manual remediation needed.
 
 
-#### 1.2.27
-Ensure that the `--service-account-lookup` argument is set to `true` (Scored)
+#### 1.2.24
+Ensure that the `--service-account-lookup` argument is set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 If `--service-account-lookup` is not enabled, the apiserver only verifies that the authentication token is valid, and does not validate that the service account token mentioned in the request is actually present in etcd. This allows using a service account token even after the corresponding service account is deleted. This is an example of time of check to time of use security issue.
@@ -1057,8 +992,8 @@ Verify that if the `--service-account-lookup` argument exists it is set to true.
 By default, RKE2 doesn't set this argument in favor of taking the default effect. No manual remediation needed.
 
 
-#### 1.2.28
-Ensure that the `--service-account-key-file` argument is set as appropriate (Scored)
+#### 1.2.25
+Ensure that the `--service-account-key-file` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 By default, if no `--service-account-key-file` is specified to the apiserver, it uses the private key from the TLS serving certificate to verify service account tokens. To ensure that the keys for service account tokens could be rotated as needed, a separate public/private key pair should be used for signing service account tokens. Hence, the public key should be specified to the apiserver with `--service-account-key-file`.
@@ -1079,8 +1014,8 @@ Verify that the `--service-account-key-file` argument exists and is set as appro
 By default, RKE2 sets the `--service-account-key-file` explicitly. No manual remediation needed.
 
 
-#### 1.2.29
-Ensure that the `--etcd-certfile` and `--etcd-keyfile` arguments are set as appropriate (Scored)
+#### 1.2.26
+Ensure that the `--etcd-certfile` and `--etcd-keyfile` arguments are set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be protected by client authentication. This requires the API server to identify itself to the etcd server using a client certificate and key.
@@ -1101,8 +1036,8 @@ Verify that the `--etcd-certfile` and `--etcd-keyfile` arguments exist and they 
 By default, RKE2 sets the `--etcd-certfile` and `--etcd-keyfile` arguments explicitly. No manual remediation needed.
 
 
-#### 1.2.30
-Ensure that the `--tls-cert-file` and `--tls-private-key-file` arguments are set as appropriate (Scored)
+#### 1.2.27
+Ensure that the `--tls-cert-file` and `--tls-private-key-file` arguments are set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 API server communication contains sensitive parameters that should remain encrypted in transit. Configure the API server to serve only HTTPS traffic.
@@ -1123,8 +1058,8 @@ Verify that the `--tls-cert-file` and `--tls-private-key-file` arguments exist a
 By default, RKE2 sets the `--tls-cert-file` and `--tls-private-key-file` arguments explicitly. No manual remediation needed.
 
 
-#### 1.2.31
-Ensure that the `--client-ca-file` argument is set as appropriate (Scored)
+#### 1.2.28
+Ensure that the `--client-ca-file` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 API server communication contains sensitive parameters that should remain encrypted in transit. Configure the API server to serve only HTTPS traffic. If `--client-ca-file` argument is set, any request presenting a client certificate signed by one of the authorities in the `client-ca-file` is authenticated with an identity corresponding to the CommonName of the client certificate.
@@ -1145,8 +1080,8 @@ Verify that the `--client-ca-file` argument exists and it is set as appropriate.
 By default, RKE2 sets the `--client-ca-file` argument explicitly. No manual remediation needed.
 
 
-#### 1.2.32
-Ensure that the `--etcd-cafile` argument is set as appropriate (Scored)
+#### 1.2.29
+Ensure that the `--etcd-cafile` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be protected by client authentication. This requires the API server to identify itself to the etcd server using a SSL Certificate Authority file.
@@ -1167,8 +1102,8 @@ Verify that the `--etcd-cafile` argument exists and it is set as appropriate.
 By default, RKE2 sets the `--etcd-cafile` argument explicitly. No manual remediation needed.
 
 
-#### 1.2.33
-Ensure that the `--encryption-provider-config` argument is set as appropriate (Scored)
+#### 1.2.30
+Ensure that the `--encryption-provider-config` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be encrypted at rest to avoid any disclosures.
@@ -1189,8 +1124,8 @@ Verify that the `--encryption-provider-config` argument is set to a EncryptionCo
 By default, RKE2 sets the `--encryption-provider-config` argument explicitly. No manual remediation needed. RKE2's default encryption provider config file is located at `/var/lib/rancher/rke2/server/cred/encryption-config.json` and is configured to encrypt secrets.
 
 
-#### 1.2.34
-Ensure that encryption providers are appropriately configured (Scored)
+#### 1.2.31
+Ensure that encryption providers are appropriately configured (Automated)
 <details>
 <summary>Rationale</summary>
 Where `etcd` encryption is used, it is important to ensure that the appropriate set of encryption providers is used. Currently, the `aescbc`, `kms` and `secretbox` are likely to be appropriate options.
@@ -1217,15 +1152,15 @@ Verify that aescbc is set as the encryption provider for all the desired resourc
 By default, RKE2 sets the argument `--encryption-provider-config` and parameter. The contents of the config file indicates the use of aescbc. No manual remediation needed.
 
 
-#### 1.2.35
-Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Not Scored)
+#### 1.2.32
+Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)
 
 <details>
 <summary>Rationale</summary>
 TLS ciphers have had a number of known vulnerabilities and weaknesses, which can reduce the protection provided by them. By default Kubernetes supports a number of TLS ciphersuites including some that have security concerns, weakening the protection provided.
 </details>
 
-**Result:** **Not Scored - Operator Dependent**
+**Result:** **Manual - Operator Dependent**
 
 **Audit:**
 Run the below command on the master node.
@@ -1243,13 +1178,13 @@ By default, RKE2 explicitly doesn't set this flag. No manual remediation needed.
 ### 1.3 Controller Manager
 
 #### 1.3.1
-Ensure that the `--terminated-pod-gc-threshold` argument is set as appropriate (Not Scored)
+Ensure that the `--terminated-pod-gc-threshold` argument is set as appropriate (Manual)
 <details>
 <summary>Rationale</summary>
 Garbage collection is important to ensure sufficient resource availability and avoiding degraded performance and availability. In the worst case, the system might crash or just be unusable for a long period of time. The current setting for garbage collection is 12,500 terminated pods which might be too high for your system to sustain. Based on your system resources and tests, choose an appropriate threshold value to activate garbage collection.
 </details>
 
-**Result:** **Not Scored - Operator Dependent**
+**Result:** **Manual - Operator Dependent**
 
 **Audit:**
 Run the below command on the master node.
@@ -1265,7 +1200,7 @@ By default, RKE2 sets the `--terminated-pod-gc-threshold` argument with a value 
 
 
 #### 1.3.2
-Ensure that the `--profiling` argument is set to false (Scored)
+Ensure that the `--profiling` argument is set to false (Automated)
 <details>
 <summary>Rationale</summary>
 Profiling allows for the identification of specific performance bottlenecks. It generates a significant amount of program data that could potentially be exploited to uncover system and program details. If you are not experiencing any bottlenecks and do not need the profiler for troubleshooting purposes, it is recommended to turn it off to reduce the potential attack surface.
@@ -1287,7 +1222,7 @@ By default, RKE2 sets the `--profiling` flag parameter to false. No manual remed
 
 
 #### 1.3.3
-Ensure that the `--use-service-account-credentials` argument is set to `true` (Scored)
+Ensure that the `--use-service-account-credentials` argument is set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 The controller manager creates a service account per controller in the `kube-system` namespace, generates a credential for it, and builds a dedicated API client with that service account credential for each controller loop to use. Setting the `--use-service-account-credentials` to `true` runs each control loop within the controller manager using a separate service account credential. When used in combination with RBAC, this ensures that the control loops run with the minimum permissions required to perform their intended tasks.
@@ -1309,7 +1244,7 @@ By default, RKE2 sets the `--use-service-account-credentials` argument to true. 
 
 
 #### 1.3.4
-Ensure that the `--service-account-private-key-file` argument is set as appropriate (Scored)
+Ensure that the `--service-account-private-key-file` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 To ensure that keys for service account tokens can be rotated as needed, a separate public/private key pair should be used for signing service account tokens. The private key should be specified to the controller manager with `--service-account-private-key-file` as appropriate.
@@ -1331,7 +1266,7 @@ By default, RKE2 sets the `--service-account-private-key-file` argument with the
 
 
 #### 1.3.5
-Ensure that the `--root-ca-file` argument is set as appropriate (Scored)
+Ensure that the `--root-ca-file` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 Processes running within pods that need to contact the API server must verify the API server's serving certificate. Failing to do so could be a subject to man-in-the-middle attacks.
@@ -1355,7 +1290,7 @@ By default, RKE2 sets the `--root-ca-file` argument with the root ca file. No ma
 
 
 #### 1.3.6
-Ensure that the `RotateKubeletServerCertificate` argument is set to `true` (Scored)
+Ensure that the `RotateKubeletServerCertificate` argument is set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 `RotateKubeletServerCertificate` causes the kubelet to both request a serving certificate after bootstrapping its client credentials and rotate the certificate as its existing credentials expire. This automated periodic rotation ensures that the there are no downtimes due to expired certificates and thus addressing availability in the CIA security triad.
@@ -1379,7 +1314,7 @@ By default, RKE2 implements it's own logic for certificate generation and rotati
 
 
 #### 1.3.7
-Ensure that the `--bind-address` argument is set to `127.0.0.1` (Scored)
+Ensure that the `--bind-address` argument is set to `127.0.0.1` (Automated)
 <details>
 <summary>Rationale</summary>
 The Controller Manager API service which runs on port 10252/TCP by default is used for health and metrics information and is available without authentication or encryption. As such it should only be bound to a localhost interface, to minimize the cluster's attack surface.
@@ -1405,7 +1340,7 @@ This section contains recommendations relating to Scheduler configuration flags
 
 
 #### 1.4.1
-Ensure that the `--profiling` argument is set to `false` (Scored)
+Ensure that the `--profiling` argument is set to `false` (Automated)
 <details>
 <summary>Rationale</summary>
 Profiling allows for the identification of specific performance bottlenecks. It generates a significant amount of program data that could potentially be exploited to uncover system and program details. If you are not experiencing any bottlenecks and do not need the profiler for troubleshooting purposes, it is recommended to turn it off to reduce the potential attack surface.
@@ -1427,7 +1362,7 @@ By default, RKE2 sets the `--profiling` flag parameter to false. No manual remed
 
 
 #### 1.4.2
-Ensure that the `--bind-address` argument is set to `127.0.0.1` (Scored)
+Ensure that the `--bind-address` argument is set to `127.0.0.1` (Automated)
 <details>
 <summary>Rationale</summary>
 
@@ -1453,13 +1388,13 @@ By default, RKE2 sets the `--bind-address` argument to `127.0.0.1`. No manual re
 This section covers recommendations for etcd configuration.
 
 #### 2.1
-Ensure that the `cert-file` and `key-file` fields are set as appropriate (Scored)
+Ensure that the `cert-file` and `key-file` fields are set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be encrypted in transit.
 </details>
 
-**Result:** Pass
+**Result:** Not Applicable
 
 **Audit:**
 Run the below command on the master node.
@@ -1475,13 +1410,13 @@ By default, RKE2 uses a config file for etcd that can be found at `/var/lib/ranc
 
 
 #### 2.2
-Ensure that the `client-cert-auth` field is set to `true` (Scored)
+Ensure that the `client-cert-auth` field is set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should not be available to unauthenticated clients. You should enable the client authentication via valid certificates to secure the access to the etcd service.
 </details>
 
-**Result:** Pass
+**Result:** Not Applicable
 
 **Audit:**
 Run the below command on the master node.
@@ -1497,7 +1432,7 @@ By default, RKE2 uses a config file for etcd that can be found at `/var/lib/ranc
 
 
 #### 2.3
-Ensure that the `auto-tls` field is not set to `true` (Scored)
+Ensure that the `auto-tls` field is not set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should not be available to unauthenticated clients. You should enable the client authentication via valid certificates to secure the access to the etcd service.
@@ -1519,13 +1454,13 @@ By default, RKE2 uses a config file for etcd that can be found at `/var/lib/ranc
 
 
 #### 2.4
-Ensure that the `peer-cert-file` and `peer-key-file` fields are set as appropriate (Scored)
+Ensure that the `peer-cert-file` and `peer-key-file` fields are set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be encrypted in transit and also amongst peers in the etcd clusters.
 </details>
 
-**Result:** Pass
+**Result:** Not Applicable
 
 **Audit:**
 Run the below command on the master node.
@@ -1541,7 +1476,7 @@ By default, RKE2 uses a config file for etcd that can be found at `/var/lib/ranc
 
 
 #### 2.5
-Ensure that the `client-cert-auth` field is set to `true` (Scored)
+Ensure that the peer-client-cert-auth argument is set to true (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be accessible only by authenticated etcd peers in the etcd cluster.
@@ -1553,17 +1488,17 @@ etcd is a highly-available key value store used by Kubernetes deployments for pe
 Run the below command on the master node.
 
 ```bash
-grep 'client-cert-auth' /var/lib/rancher/rke2/server/db/etcd/config
+grep 'peer-client-cert-auth' /var/lib/rancher/rke2/server/db/etcd/config
 ```
 
-Verify that the `client-cert-auth` field in the peer section is set to true.
+Verify that the `peer-client-cert-auth` field in the peer section is set to true.
 
 **Remediation:**
 By default, RKE2 uses a config file for etcd that can be found at `/var/lib/rancher/rke2/server/db/etcd/config`. Within the file, the `client-cert-auth` field is set. No manual remediation needed.
 
 
 #### 2.6
-Ensure that the `peer-auto-tls` field is not set to `true` (Scored)
+Ensure that the `peer-auto-tls` field is not set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 etcd is a highly-available key value store used by Kubernetes deployments for persistent storage of all of its REST API objects. These objects are sensitive in nature and should be accessible only by authenticated etcd peers in the etcd cluster. Hence, do not use self- signed certificates for authentication.
@@ -1585,7 +1520,7 @@ By default, RKE2 uses a config file for etcd that can be found at `/var/lib/ranc
 
 
 #### 2.7
-Ensure that a unique Certificate Authority is used for etcd (Not Scored)
+Ensure that a unique Certificate Authority is used for etcd (Manual)
 <details>
 <summary>Rationale</summary>
 etcd is a highly available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. Its access should be restricted to specifically designated clients and peers only.
@@ -1619,13 +1554,13 @@ By default, RKE2 uses a config file for etcd that can be found at `/var/lib/ranc
 
 
 #### 3.1.1
-Client certificate authentication should not be used for users (Not Scored)
+Client certificate authentication should not be used for users (Manual)
 <details>
 <summary>Rationale</summary>
 With any authentication mechanism the ability to revoke credentials if they are compromised or no longer required, is a key control. Kubernetes client certificate authentication does not allow for this due to a lack of support for certificate revocation.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Audit:**
 Review user access to the cluster and ensure that users are not making use of Kubernetes client certificate authentication.
@@ -1637,7 +1572,7 @@ Alternative mechanisms provided by Kubernetes such as the use of OIDC should be 
 
 
 #### 3.2.1
-Ensure that a minimal audit policy is created (Scored)
+Ensure that a minimal audit policy is created (Automated)
 <details>
 <summary>Rationale</summary>
 Logging is an important detective control for all systems, to detect potential unauthorised access.
@@ -1659,13 +1594,13 @@ Create an audit policy file for your cluster.
 
 
 #### 3.2.2
-Ensure that the audit policy covers key security concerns (Not Scored)
+Ensure that the audit policy covers key security concerns (Manual)
 <details>
 <summary>Rationale</summary>
 Security audit logs should cover access and modification of key resources in the cluster, to enable them to form an effective part of a security environment.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Remediation:**
 
@@ -1677,7 +1612,7 @@ Security audit logs should cover access and modification of key resources in the
 
 
 #### 4.1.1
-Ensure that the kubelet service file permissions are set to `644` or more restrictive (Scored)
+Ensure that the kubelet service file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The `kubelet` service file controls various parameters that set the behavior of the kubelet service in the worker node. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -1690,7 +1625,7 @@ RKE2 doesn’t launch the kubelet as a service. It is launched and managed by th
 
 
 #### 4.1.2
-Ensure that the kubelet service file ownership is set to `root:root` (Scored)
+Ensure that the kubelet service file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The `kubelet` service file controls various parameters that set the behavior of the kubelet service in the worker node. You should set its file ownership to maintain the integrity of the file. The file should be owned by `root:root`.
@@ -1703,7 +1638,7 @@ RKE2 doesn’t launch the kubelet as a service. It is launched and managed by th
 
 
 #### 4.1.3
-Ensure that the proxy kubeconfig file permissions are set to `644` or more restrictive (Scored)
+Ensure that the proxy kubeconfig file permissions are set to `644` or more restrictive (Manual)
 <details>
 <summary>Rationale</summary>
 The `kube-proxy` kubeconfig file controls various parameters of the `kube-proxy` service in the worker node. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -1728,7 +1663,7 @@ By derfault, RKE2 creates `rke2-kube-proxy.yaml` with `644` permissions. No manu
 
 
 #### 4.1.4
-Ensure that the proxy kubeconfig file ownership is set to `root:root` (Scored)
+Ensure that the proxy kubeconfig file ownership is set to `root:root` (Manual)
 <details>
 <summary>Rationale</summary>
 The kubeconfig file for `kube-proxy` controls various parameters for the `kube-proxy` service in the worker node. You should set its file ownership to maintain the integrity of the file. The file should be owned by `root:root`.
@@ -1751,7 +1686,7 @@ By default, RKE2 creates `rke2-kube-proxy.yaml` with `root:root` ownership. No m
 
 
 #### 4.1.5
-Ensure that the kubelet.conf file permissions are set to `644` or more restrictive (Scored)
+Ensure that the kubelet.conf file permissions are set to `644` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The `kubelet.conf` file is the kubeconfig file for the node, and controls various parameters that set the behavior and identity of the worker node. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -1771,7 +1706,7 @@ stat -c %a /var/lib/rancher/rke2/agent/kubelet.kubeconfig
 By derfault, RKE2 creates `kubelet.kubeconfig` with `644` permissions. No manual remediation needed.
 
 #### 4.1.6
-Ensure that the kubelet.conf file ownership is set to `root:root` (Scored)
+Ensure that the kubelet.conf file ownership is set to `root:root` (Manual)
 <details>
 <summary>Rationale</summary>
 The `kubelet.conf` file is the kubeconfig file for the node, and controls various parameters that set the behavior and identity of the worker node. You should set its file ownership to maintain the integrity of the file. The file should be owned by `root:root`.
@@ -1792,13 +1727,13 @@ By default, RKE2 creates `kubelet.kubeconfig` with `root:root` ownership. No man
 
 
 #### 4.1.7
-Ensure that the certificate authorities file permissions are set to `644` or more restrictive (Scored)
+Ensure that the certificate authorities file permissions are set to `644` or more restrictive (Manual)
 <details>
 <summary>Rationale</summary>
 The certificate authorities file controls the authorities used to validate API requests. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
 </details>
 
-**Result:** Pass
+**Result:** Manual - Operator Dependent
 
 **Audit:**
 Run the below command on the master node.
@@ -1815,7 +1750,7 @@ By default, RKE2 creates `/var/lib/rancher/rke2/server/tls/server-ca.crt` with 6
 
 
 #### 4.1.8
-Ensure that the client certificate authorities file ownership is set to `root:root` (Scored)
+Ensure that the client certificate authorities file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The certificate authorities file controls the authorities used to validate API requests. You should set its file ownership to maintain the integrity of the file. The file should be owned by `root:root`.
@@ -1836,7 +1771,7 @@ By default, RKE2 creates `/var/lib/rancher/rke2/server/tls/client-ca.crt` with `
 
 
 #### 4.1.9
-Ensure that the kubelet configuration file has permissions set to `644` or more restrictive (Scored)
+Ensure that the kubelet configuration file has permissions set to `600` or more restrictive (Automated)
 <details>
 <summary>Rationale</summary>
 The kubelet reads various parameters, including security settings, from a config file specified by the `--config` argument. If this file is specified you should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.
@@ -1849,7 +1784,7 @@ RKE2 doesn’t require or maintain a configuration file for the kubelet process.
 
 
 #### 4.1.10
-Ensure that the kubelet configuration file ownership is set to `root:root` (Scored)
+Ensure that the kubelet configuration file ownership is set to `root:root` (Automated)
 <details>
 <summary>Rationale</summary>
 The kubelet reads various parameters, including security settings, from a config file specified by the `--config` argument. If this file is specified you should restrict its file permissions to maintain the integrity of the file. The file should be owned by `root:root`.
@@ -1866,7 +1801,7 @@ This section contains recommendations for kubelet configuration.
 
 
 #### 4.2.1
-Ensure that the `--anonymous-auth` argument is set to false (Scored)
+Ensure that the `--anonymous-auth` argument is set to false (Automated)
 <details>
 <summary>Rationale</summary>
 When enabled, requests that are not rejected by other configured authentication methods are treated as anonymous requests. These requests are then served by the Kubelet server. You should rely on authentication to authorize access and disallow anonymous requests.
@@ -1887,7 +1822,7 @@ Verify that the value for `--anonymous-auth` is false.
 By default, RKE2 starts kubelet with `--anonymous-auth` set to false. No manual remediation needed.
 
 #### 4.2.2
-Ensure that the `--authorization-mode` argument is not set to `AlwaysAllow` (Scored)
+Ensure that the `--authorization-mode` argument is not set to `AlwaysAllow` (Automated)
 <details>
 <summary>Rationale</summary>
 Kubelets, by default, allow all authenticated requests (even anonymous ones) without needing explicit authorization checks from the apiserver. You should restrict this behavior and only allow explicitly authorized requests.
@@ -1909,7 +1844,7 @@ RKE2 starts kubelet with `Webhook` as the value for the `--authorization-mode` a
 
 
 #### 4.2.3
-Ensure that the `--client-ca-file` argument is set as appropriate (Scored)
+Ensure that the `--client-ca-file` argument is set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 The connections from the apiserver to the kubelet are used for fetching logs for pods, attaching (through kubectl) to running pods, and using the kubelet’s port-forwarding functionality. These connections terminate at the kubelet’s HTTPS endpoint. By default, the apiserver does not verify the kubelet’s serving certificate, which makes the connection subject to man-in-the-middle attacks, and unsafe to run over untrusted and/or public networks. Enabling Kubelet certificate authentication ensures that the apiserver could authenticate the Kubelet before submitting any requests.
@@ -1931,7 +1866,7 @@ By default, RKE2 starts the kubelet process with the `--client-ca-file`. No manu
 
 
 #### 4.2.4
-Ensure that the `--read-only-port` argument is set to `0` (Scored)
+Ensure that the `--read-only-port` argument is set to `0` (Automated)
 <details>
 <summary>Rationale</summary>
 The Kubelet process provides a read-only API in addition to the main Kubelet API. Unauthenticated access is provided to this read-only API which could possibly retrieve potentially sensitive information about the cluster.
@@ -1952,7 +1887,7 @@ By default, RKE2 starts the kubelet process with the `--read-only-port` argument
 
 
 #### 4.2.5
-Ensure that the `--streaming-connection-idle-timeout` argument is not set to `0` (Scored)
+Ensure that the `--streaming-connection-idle-timeout` argument is not set to `0` (Automated)
 <details>
 <summary>Rationale</summary>
 Setting idle timeouts ensures that you are protected against Denial-of-Service attacks, inactive connections and running out of ephemeral ports.
@@ -1976,7 +1911,7 @@ By default, RKE2 does not set `--streaming-connection-idle-timeout` when startin
 
 
 #### 4.2.6
-Ensure that the `--protect-kernel-defaults` argument is set to `true` (Scored)
+Ensure that the `--protect-kernel-defaults` argument is set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 Kernel parameters are usually tuned and hardened by the system administrators before putting the systems into production. These parameters protect the kernel and the system. Your kubelet kernel defaults that rely on such parameters should be appropriately set to match the desired secured system state. Ignoring this could potentially lead to running pods with undesired kernel behavior.
@@ -1992,11 +1927,11 @@ Run the below command on the master node.
 ```
 
 **Remediation:**
-When running with the `profile` flag set to `cis-1.5`, RKE2 starts the kubelet process with the `--protect-kernel-defaults` argument set to true.
+When running with the `profile` flag set to `cis-1.23`, RKE2 starts the kubelet process with the `--protect-kernel-defaults` argument set to true.
 
 
 #### 4.2.7
-Ensure that the `--make-iptables-util-chains` argument is set to `true` (Scored)
+Ensure that the `--make-iptables-util-chains` argument is set to `true` (Automated)
 <details>
 <summary>Rationale</summary>
 Kubelets can automatically manage the required changes to iptables based on how you choose your networking options for the pods. It is recommended to let kubelets manage the changes to iptables. This ensures that the iptables configuration remains in sync with pods networking configuration. Manually configuring iptables with dynamic pod network configuration changes might hamper the communication between pods/containers and to the outside world. You might have iptables rules too restrictive or too open.
@@ -2018,7 +1953,7 @@ By default, RKE2 does not set the `--make-iptables-util-chains` argument. No man
 
 
 #### 4.2.8
-Ensure that the `--hostname-override` argument is not set (Not Scored)
+Ensure that the `--hostname-override` argument is not set (Manual)
 <details>
 <summary>Rationale</summary>
 Overriding hostnames could potentially break TLS setup between the kubelet and the apiserver. Additionally, with overridden hostnames, it becomes increasingly difficult to associate logs with a particular node and process them for security analytics. Hence, you should setup your kubelet nodes with resolvable FQDNs and avoid overriding the hostnames with IPs.
@@ -2031,19 +1966,19 @@ RKE2 does set this parameter for each host, but RKE2 also manages all certificat
 
 
 #### 4.2.9
-Ensure that the `--event-qps` argument is set to 0 or a level which ensures appropriate event capture (Not Scored)
+Ensure that the `--event-qps` argument is set to 0 or a level which ensures appropriate event capture (Manual)
 <details>
 <summary>Rationale</summary>
 It is important to capture all events and not restrict event creation. Events are an important source of security information and analytics that ensure that your environment is consistently monitored using the event data.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Remediation:**
 See CIS Benchmark guide for further details on configuring this.
 
 #### 4.2.10
-Ensure that the `--tls-cert-file` and `--tls-private-key-file` arguments are set as appropriate (Scored)
+Ensure that the `--tls-cert-file` and `--tls-private-key-file` arguments are set as appropriate (Automated)
 <details>
 <summary>Rationale</summary>
 Kubelet communication contains sensitive parameters that should remain encrypted in transit. Configure the Kubelets to serve only HTTPS traffic.
@@ -2065,7 +2000,7 @@ By default, RKE2 sets the `--tls-cert-file` and `--tls-private-key-file` argumen
 
 
 #### 4.2.11
-Ensure that the `--rotate-certificates` argument is not set to `false` (Scored)
+Ensure that the `--rotate-certificates` argument is not set to `false` (Manual)
 <details>
 <summary>Rationale</summary>
 
@@ -2076,7 +2011,7 @@ The `--rotate-certificates` setting causes the kubelet to rotate its client cert
 **Note:**This feature also require the `RotateKubeletClientCertificate` feature gate to be enabled (which is the default since Kubernetes v1.7)
 </details>
 
-**Result:** Not Applicable
+**Result:** Pass
 
 **Audit:**
 Run the below command on the master node.
@@ -2090,7 +2025,7 @@ By default, RKE2 implements it's own logic for certificate generation and rotati
 
 
 #### 4.2.12
-Ensure that the `RotateKubeletServerCertificate` argument is set to `true` (Scored)
+Ensure that the `RotateKubeletServerCertificate` argument is set to `true` (Manual)
 <details>
 <summary>Rationale</summary>
 `RotateKubeletServerCertificate` causes the kubelet to both request a serving certificate after bootstrapping its client credentials and rotate the certificate as its existing credentials expire. This automated periodic rotation ensures that the there are no downtimes due to expired certificates and thus addressing availability in the CIA security triad.
@@ -2098,7 +2033,7 @@ Ensure that the `RotateKubeletServerCertificate` argument is set to `true` (Scor
 Note: This recommendation only applies if you let kubelets get their certificates from the API server. In case your kubelet certificates come from an outside authority/tool (e.g. Vault) then you need to take care of rotation yourself.
 </details>
 
-**Result:** Not Applicable
+**Result:** Pass
 
 **Audit:**
 Run the below command on the master node.
@@ -2112,13 +2047,13 @@ By default, RKE2 implements it's own logic for certificate generation and rotati
 
 
 #### 4.2.13
-Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Not Scored)
+Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)
 <details>
 <summary>Rationale</summary>
 TLS ciphers have had a number of known vulnerabilities and weaknesses, which can reduce the protection provided by them. By default Kubernetes supports a number of TLS ciphersuites including some that have security concerns, weakening the protection provided.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Remediation:**
 Configuration of the parameter is dependent on your use case. Please see the CIS Kubernetes Benchmark for suggestions on configuring this for your usecase.
@@ -2131,7 +2066,7 @@ Configuration of the parameter is dependent on your use case. Please see the CIS
 
 
 #### 5.1.1
-Ensure that the cluster-admin role is only used where required (Not Scored)
+Ensure that the cluster-admin role is only used where required (Manual)
 <details>
 <summary>Rationale</summary>
 Kubernetes provides a set of default roles where RBAC is used. Some of these roles such as `cluster-admin` provide wide-ranging privileges which should only be applied where absolutely necessary. Roles such as `cluster-admin` allow super-user access to perform any action on any resource. When used in a `ClusterRoleBinding`, it gives full control over every resource in the cluster and in all namespaces. When used in a `RoleBinding`, it gives full control over every resource in the rolebinding's namespace, including the namespace itself.
@@ -2143,25 +2078,25 @@ Kubernetes provides a set of default roles where RBAC is used. Some of these rol
 RKE2 does not make inappropriate use of the cluster-admin role. Operators must audit their workloads of additional usage. See the CIS Benchmark guide for more details.
 
 #### 5.1.2
-Minimize access to secrets (Not Scored)
+Minimize access to secrets (Manual)
 <details>
 <summary>Rationale</summary>
 Inappropriate access to secrets stored within the Kubernetes cluster can allow for an attacker to gain additional access to the Kubernetes cluster or external resources whose credentials are stored as secrets.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Remediation:**
 RKE2 limits its use of secrets for the system components appropriately, but operators must audit the use of secrets by their workloads. See the CIS Benchmark guide for more details.
 
 #### 5.1.3
-Minimize wildcard use in Roles and ClusterRoles (Not Scored)
+Minimize wildcard use in Roles and ClusterRoles (Manual)
 <details>
 <summary>Rationale</summary>
 The principle of least privilege recommends that users are provided only the access required for their role and nothing more. The use of wildcard rights grants is likely to provide excessive rights to the Kubernetes API.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Audit:**
 Run the below command on the master node.
@@ -2180,19 +2115,19 @@ Verify that there are not wildcards in use.
 Operators should review their workloads for proper role usage. See the CIS Benchmark guide for more details.
 
 #### 5.1.4
-Minimize access to create pods (Not Scored)
+Minimize access to create pods (Manual)
 <details>
 <summary>Rationale</summary>
 The ability to create pods in a cluster opens up possibilities for privilege escalation and should be restricted, where possible.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Remediation:**
 Operators should review who has access to create pods in their cluster. See the CIS Benchmark guide for more details.
 
 #### 5.1.5
-Ensure that default service accounts are not actively used. (Scored)
+Ensure that default service accounts are not actively used. (Automated)
 <details>
 <summary>Rationale</summary>
 Kubernetes provides a default service account which is used by cluster workloads where no specific service account is assigned to the pod.
@@ -2218,7 +2153,7 @@ automountServiceAccountToken: false
 
 
 #### 5.1.6
-Ensure that Service Account Tokens are only mounted where necessary (Not Scored)
+Ensure that Service Account Tokens are only mounted where necessary (Manual)
 <details>
 <summary>Rationale</summary>
 Mounting service account tokens inside pods can provide an avenue for privilege escalation attacks where an attacker is able to compromise a single pod in the cluster.
@@ -2226,41 +2161,54 @@ Mounting service account tokens inside pods can provide an avenue for privilege 
 Avoiding mounting these tokens removes this attack avenue.
 </details>
 
-**Result:** Not Scored - Operator Dependent
+**Result:** Manual - Operator Dependent
 
 **Remediation:**
 The pods launched by RKE2 are part of the control plane and generally need access to communicate with the API server, thus this control does not apply to them. Operators should review their workloads and take steps to modify the definition of pods and service accounts which do not need to mount service account tokens to disable it.
 
-### 5.2 Pod Security Policies
+#### 5.1.7
+Avoid use of system:masters group (Manual)
+<details>
+<summary>Rationale</summary>
+The system:masters group has unrestricted access to the Kubernetes API hard-coded into the API server source code. An authenticated user who is a member of this group cannot have their access reduced, even if all bindings and cluster role bindings which mention it, are removed.
+
+When combined with client certificate authentication, use of this group can allow for irrevocable cluster-admin level credentials to exist for a cluster.
+</details>
+
+**Result:** Manual - Operator Dependent
+
+**Remediation:**
+Remove the system:masters group from all users in the cluster.
+
+#### 5.1.7
+Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)
+<details>
+<summary>Rationale</summary>
+The impersonate privilege allows a subject to impersonate other users gaining their rights to the cluster. The bind privilege allows the subject to add a binding to a cluster role or role which escalates their effective permissions in the cluster. The escalate privilege allows a subject to modify cluster roles to which they are bound, increasing their rights to that level.
+</details>
+
+**Result:** Manual - Operator Dependent
+
+**Remediation:**
+ Where possible, remove the impersonate, bind and escalate rights from subjects.
+
+### 5.2 Pod Security Standards
 
 
 #### 5.2.1
-Minimize the admission of containers wishing to share the host process ID namespace (Scored)
+Ensure that the cluster has at least one active policy control mechanism in place (Manual)
 <details>
 <summary>Rationale</summary>
-Privileged containers have access to all Linux Kernel capabilities and devices. A container running with full privileges can do almost everything that the host can do. This flag exists to allow special use-cases, like manipulating the network stack and accessing devices.
-
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit privileged containers.
-
-If you need to run privileged containers, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.
+Without an active policy control mechanism, it is not possible to limit the use of containers with access to underlying cluster nodes, via mechanisms like privileged containers, or the use of hostPath volume mounts.
 </details>
 
-**Result:** Pass
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/var/lib/rancher/rke2/bin/kubectl describe psp global-restricted-psp | grep MustRunAsNonRoot
-```
-
-Verify that the result is `Rule:  MustRunAsNonRoot`.
+**Result:** Manual - Operator Dependent
 
 **Remediation:**
-RKE2, when run with the `--profile=cis-1.5` argument, will disallow the use of privileged containers.
+PSA is enabled since v1.23 by default in RKE2, no remediation necessary.
 
 #### 5.2.2
-Minimize the admission of containers wishing to share the host process ID namespace (Scored)
+Minimize the admission of privileged containers (Manual)
 <details>
 <summary>Rationale</summary>
 A container running in the host's PID namespace can inspect processes running outside the container. If the container also has access to ptrace capabilities this can be used to escalate privileges outside of the container.
@@ -2273,28 +2221,29 @@ If you need to run containers which require hostPID, this should be defined in a
 **Result:** Pass
 
 **Audit:**
-Run the below command on the master node.
+Run the below command on the master node to ensure restricted level is enabled in the config file.
 
 ```bash
-/var/lib/rancher/rke2/bin/kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostPID == null) or (.spec.hostPID == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'
+config_file=$(ps aux | grep kube-apiserver |  grep -- --admission-control-config-file | sed 's%.*admission-control-config-file[= ]\([^ ]*\).*%\1%')
+
+grep "enforce:" ${config_file}
 ```
 
-Verify that the returned count is 1.
+Verify that the returned value is `enforce: restricted`
 
 **Remediation:**
-RKE2 sets the `hostPID` value to false explicitly for the PSP it creates. When reviewing PSPs, note that the Kubernetes API only displays this field if it is explicitly set to true. No manual remediation is needed.
+Add policies to each namespace in the cluster which has user workloads to restrict the admission of privileged containers.
 
 
 #### 5.2.3
-Minimize the admission of containers wishing to share the host IPC namespace (Scored)
+Minimize the admission of containers wishing to share the host process ID namespace (Automated)
 <details>
 <summary>Rationale</summary>
+A container running in the host's PID namespace can inspect processes running outside the container. If the container also has access to ptrace capabilities this can be used to escalate privileges outside of the container.
 
-A container running in the host's IPC namespace can use IPC to interact with processes outside the container.
+There should be at least one admission control policy defined which does not permit containers to share the host PID namespace.
 
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host IPC namespace.
-
-If you have a requirement to containers which require hostIPC, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.
+If you need to run containers which require hostPID, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
 </details>
 
 **Result:** Pass
@@ -2303,24 +2252,53 @@ If you have a requirement to containers which require hostIPC, this should be de
 Run the below command on the master node.
 
 ```bash
-/var/lib/rancher/rke2/bin/kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostIPC == null) or (.spec.hostIPC == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'
+config_file=$(ps aux | grep kube-apiserver |  grep -- --admission-control-config-file | sed 's%.*admission-control-config-file[= ]\([^ ]*\).*%\1%')
+
+grep "enforce:" ${config_file}
 ```
 
-Verify that the returned count is 1.
+Verify that the returned value is `enforce: restricted`
 
 **Remediation:**
-RKE2 sets the `HostIPC` value to false explicitly for the PSP it creates. When reviewing PSPs, note that the Kubernetes API only displays this field if it is explicitly set to true. No manual remediation is needed.
+Add policies to each namespace in the cluster which has user workloads to restrict the admission of privileged containers.
 
 
 #### 5.2.4
-Minimize the admission of containers wishing to share the host network namespace (Scored)
+Minimize the admission of containers wishing to share the host IPC namespace (Automated)
+<details>
+<summary>Rationale</summary>
+A container running in the host's IPC namespace can use IPC to interact with processes outside the container.
+
+There should be at least one admission control policy defined which does not permit containers to share the host IPC namespace.
+
+If you need to run containers which require hostIPC, this should be definited in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+</details>
+
+**Result:** Pass
+
+**Audit:**
+Run the below command on the master node.
+
+```bash
+config_file=$(ps aux | grep kube-apiserver |  grep -- --admission-control-config-file | sed 's%.*admission-control-config-file[= ]\([^ ]*\).*%\1%')
+
+grep "enforce:" ${config_file}
+```
+
+Verify that the returned value is `enforce: restricted`
+
+**Remediation:**
+Add policies to each namespace in the cluster which has user workloads to restrict the admission of privileged containers.
+
+#### 5.2.5
+Minimize the admission of containers wishing to share the host network namespace (Automated)
 <details>
 <summary>Rationale</summary>
 A container running in the host's network namespace could access the local loopback device, and could access network traffic to and from other pods.
 
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host network namespace.
+There should be at least one admission control policy defined which does not permit containers to share the host network namespace.
 
-If you have need to run containers which require hostNetwork, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.
+If you need to run containers which require access to the host's network namespaces, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
 </details>
 
 **Result:** Pass
@@ -2329,52 +2307,56 @@ If you have need to run containers which require hostNetwork, this should be def
 Run the below command on the master node.
 
 ```bash
-/var/lib/rancher/rke2/bin/kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostNetwork == null) or (.spec.hostNetwork == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'
+config_file=$(ps aux | grep kube-apiserver |  grep -- --admission-control-config-file | sed 's%.*admission-control-config-file[= ]\([^ ]*\).*%\1%')
+
+grep "enforce:" ${config_file}
 ```
 
-Verify that the returned count is 1.
+Verify that the returned value is `enforce: restricted`
 
 **Remediation:**
-RKE2 sets the `HostNetwork` value to false explicitly for the PSP it creates. When reviewing PSPs, note that the Kubernetes API only displays this field if it is explicitly set to true. No manual remediation is needed.
-
-
-#### 5.2.5
-Minimize the admission of containers with `allowPrivilegeEscalation` (Scored)
-<details>
-<summary>Rationale</summary>
-A container running with the `allowPrivilegeEscalation` flag set to true may have processes that can gain more privileges than their parent.
-
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to allow privilege escalation. The option exists (and is defaulted to true) to permit setuid binaries to run.
-
-If you have need to run containers which use setuid binaries or require privilege escalation, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.
-</details>
-
-**Result:** Pass
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/var/lib/rancher/rke2/bin/kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.allowPrivilegeEscalation == null) or (.spec.allowPrivilegeEscalation == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'
-```
-
-Verify that the returned count is 1.
-
-**Remediation:**
-RKE2 sets the `allowPrivilegeEscalation` value to false explicitly for the PSP it creates. No manual remediation is needed.
+Add policies to each namespace in the cluster which has user workloads to restrict the admission of hostNetwork containers.
 
 
 #### 5.2.6
-Minimize the admission of root containers (Not Scored)
+Minimize the admission of containers with `allowPrivilegeEscalation` (Automated)
+<details>
+<summary>Rationale</summary>
+A container running with the allowPrivilegeEscalation flag set to true may have processes that can gain more privileges than their parent.
+
+There should be at least one admission control policy defined which does not permit containers to allow privilege escalation. The option exists (and is defaulted to true) to permit setuid binaries to run.
+
+If you have need to run containers which use setuid binaries or require privilege escalation, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+</details>
+
+**Result:** Pass
+
+**Audit:**
+Run the below command on the master node.
+
+```bash
+config_file=$(ps aux | grep kube-apiserver |  grep -- --admission-control-config-file | sed 's%.*admission-control-config-file[= ]\([^ ]*\).*%\1%')
+
+grep "enforce:" ${config_file}
+```
+
+Verify that the returned value is `enforce: restricted`
+
+**Remediation:**
+Add policies to each namespace in the cluster which has user workloads to restrict the admission of containers with .spec.allowPrivilegeEscalationset to true.
+
+
+#### 5.2.7
+Minimize the admission of root containers (Automated)
 <details>
 <summary>Rationale</summary>
 Containers may run as any Linux user. Containers which run as the root user, whilst constrained by Container Runtime security features still have a escalated likelihood of container breakout.
 
 Ideally, all containers should run as a defined non-UID 0 user.
 
-There should be at least one PodSecurityPolicy (PSP) defined which does not permit root users in a container.
+There should be at least one admission control policy defined which does not permit root containers.
 
-If you need to run root containers, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.
+If you need to run root containers, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
 </details>
 
 **Result:** Pass
@@ -2383,26 +2365,28 @@ If you need to run root containers, this should be defined in a separate PSP and
 Run the below command on the master node.
 
 ```bash
-/var/lib/rancher/rke2/bin/kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.allowPrivilegeEscalation == null) or (.spec.allowPrivilegeEscalation == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'
+config_file=$(ps aux | grep kube-apiserver |  grep -- --admission-control-config-file | sed 's%.*admission-control-config-file[= ]\([^ ]*\).*%\1%')
+
+grep "enforce:" ${config_file}
 ```
 
-Verify that the returned count is 1.
+Verify that the returned value is `enforce: restricted`
 
 **Remediation:**
-RKE2 sets the `runAsUser.Rule` value to `MustRunAsNonRoot` in the PodSecurityPolicy that it creates. No manual remediation is needed.
+Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot` or `MustRunAs` with the range of UIDs not including 0, is set.
 
 
-#### 5.2.7
-Minimize the admission of containers with the NET_RAW capability (Not Scored)
+#### 5.2.8
+Minimize the admission of containers with the NET_RAW capability (Automated)
 <details>
 <summary>Rationale</summary>
 Containers run with a default set of capabilities as assigned by the Container Runtime. By default this can include potentially dangerous capabilities. With Docker as the container runtime the NET_RAW capability is enabled which may be misused by malicious containers.
 
 Ideally, all containers should drop this capability.
 
-There should be at least one PodSecurityPolicy (PSP) defined which prevents containers with the NET_RAW capability from launching.
+There should be at least one admission control policy defined which does not permit containers with the NET_RAW capability.
 
-If you need to run containers with this capability, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.
+If you need to run containers with this capability, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
 </details>
 
 **Result:** Pass
@@ -2411,43 +2395,36 @@ If you need to run containers with this capability, this should be defined in a 
 Run the below command on the master node.
 
 ```bash
-/var/lib/rancher/rke2/bin/kubectl get psp global-restricted-psp -o json | jq .spec.requiredDropCapabilities[]
+config_file=$(ps aux | grep kube-apiserver |  grep -- --admission-control-config-file | sed 's%.*admission-control-config-file[= ]\([^ ]*\).*%\1%')
+
+grep "enforce:" ${config_file}
 ```
 
-Verify the value is `"ALL"`.
+Verify that the returned value is `enforce: restricted`.
 
 **Remediation:**
-RKE2 sets `.spec.requiredDropCapabilities[]` to a value of `All`. No manual remediation needed.
+Add policies to each namespace in the cluster which has user workloads to restrict the admission of containers with the `NET_RAW` capability.
 
 
-#### 5.2.8
-Minimize the admission of containers with added capabilities (Not Scored)
+#### 5.2.9
+Minimize the admission of containers with added capabilities (Automated)
 <details>
 <summary>Rationale</summary>
 Containers run with a default set of capabilities as assigned by the Container Runtime. Capabilities outside this set can be added to containers which could expose them to risks of container breakout attacks.
 
-There should be at least one PodSecurityPolicy (PSP) defined which prevents containers with capabilities beyond the default set from launching.
+There should be at least one policy defined which prevents containers with capabilities beyond the default set from launching.
 
-If you need to run containers with additional capabilities, this should be defined in a separate PSP and you should carefully check RBAC controls to ensure that only limited service accounts and users are given permission to access that PSP.
+If you need to run containers with additional capabilities, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
 </details>
 
-**Result:** Not Scored
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/var/lib/rancher/rke2/bin/kubectl get psp
-```
-
-Verify that there are no PSPs present which have `allowedCapabilities` set to anything other than an empty array.
+**Result:** Manual
 
 **Remediation:**
-When run with the `--profile=cis-1.5` argument RKE2 applies a PodSecurityPolicy that sets `requiredDropCapabilities` to `ALL`. No manual remediation needed.
+Ensure that `allowedCapabilities` is not present in policies for the cluster unless it is set to an empty array.
 
 
-#### 5.2.9
-Minimize the admission of containers with capabilities assigned (Not Scored)
+#### 5.2.10
+Minimize the admission of containers with capabilities assigned (Manual)
 <details>
 <summary>Rationale</summary>
 Containers run with a default set of capabilities as assigned by the Container Runtime. Capabilities are parts of the rights generally granted on a Linux system to the root user.
@@ -2455,24 +2432,63 @@ Containers run with a default set of capabilities as assigned by the Container R
 In many cases applications running in containers do not require any capabilities to operate, so from the perspective of the principal of least privilege use of capabilities should be minimized.
 </details>
 
-**Result:** Not Scored
-
-**Audit:**
-Run the below command on the master node.
-
-```bash
-/var/lib/rancher/rke2/bin/kubectl get psp
-```
+**Result:** Manual
 
 **Remediation:**
-When run with the `--profile=cis-1.5` argument RKE2 applies a PodSecurityPolicy that sets `requiredDropCapabilities` to `ALL`. No manual remediation needed.
+Review the use of capabilities in applications running on your cluster. Where a namespace contains applicaions which do not require any Linux capabities to operate consider adding a PSP which forbids the admission of containers which do not drop all capabilities.
 
+
+#### 5.2.11
+Minimize the admission of Windows HostProcess containers (Manual)
+<details>
+<summary>Rationale</summary>
+Containers run with a default set of capabilities as assigned by the Container Runtime. Capabilities are parts of the rights generally granted on a Linux system to the root user.
+
+In many cases applications running in containers do not require any capabilities to operate, so from the perspective of the principal of least privilege use of capabilities should be minimized.
+</details>
+
+**Result:** Manual
+
+**Remediation:**
+ Add policies to each namespace in the cluster which has user workloads to restrict the admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
+
+#### 5.2.12
+Minimize the admission of HostPath volumes (Manual)
+<details>
+<summary>Rationale</summary>
+A container which mounts a hostPath volume as part of its specification will have access to the filesystem of the underlying cluster node. The use of hostPath volumes may allow containers access to privileged areas of the node filesystem.
+
+There should be at least one admission control policy defined which does not permit containers to mount hostPath volumes.
+
+If you need to run containers which require hostPath volumes, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+</details>
+
+**Result:** Manual
+
+**Remediation:**
+ Add policies to each namespace in the cluster which has user workloads to restrict the admission of containers with `hostPath` volumes.
+
+ #### 5.2.13
+Minimize the admission of containers which use HostPorts (Manual)
+<details>
+<summary>Rationale</summary>
+Host ports connect containers directly to the host's network. This can bypass controls such as network policy.
+
+There should be at least one admission control policy defined which does not permit containers which require the use of HostPorts.
+
+If you need to run containers which require HostPorts, this should be defined in a separate policy and you should carefully check to ensure that only limited service accounts and users are given permission to use that policy.
+</details>
+
+**Result:** Manual
+
+**Remediation:**
+ Add policies to each namespace in the cluster which has user workloads to restrict the admission of containers which use `hostPort` sections.
 
 ### 5.3 Network Policies and CNI
 
 
 #### 5.3.1
-Ensure that the CNI in use supports Network Policies (Not Scored)
+Ensure that the CNI in use supports Network Policies (Automated)
 <details>
 <summary>Rationale</summary>
 Kubernetes network policies are enforced by the CNI plugin in use. As such it is important to ensure that the CNI plugin supports both Ingress and Egress network policies.
@@ -2488,7 +2504,7 @@ By default, RKE2 use Canal (Calico and Flannel) and fully supports network polic
 
 
 #### 5.3.2
-Ensure that all Namespaces have Network Policies defined (Scored)
+Ensure that all Namespaces have Network Policies defined (Automated)
 <details>
 <summary>Rationale</summary>
 Running different applications on the same Kubernetes cluster creates a risk of one compromised application attacking a neighboring application. Network segmentation is important to ensure that containers can communicate only with those they are supposed to. A network policy is a specification of how selections of pods are allowed to communicate with each other and other network endpoints.
@@ -2510,19 +2526,19 @@ done
 Verify that there are network policies applied to each of the namespaces.
 
 **Remediation:**
-RKE2, when executed with the `--profile=cis-1.5` argument applies a secure network policy that only allows intra-namespace traffic and DNS to kube-system. No manual remediation needed.
+RKE2, when executed with the `--profile=cis-1.23` argument applies a secure network policy that only allows intra-namespace traffic and DNS to kube-system. No manual remediation needed.
 
 ### 5.4 Secrets Management
 
 
 #### 5.4.1
-Prefer using secrets as files over secrets as environment variables (Not Scored)
+Prefer using secrets as files over secrets as environment variables (Manual)
 <details>
 <summary>Rationale</summary>
 It is reasonably common for application code to log out its environment (particularly in the event of an error). This will include any secret values passed in as environment variables, so secrets can easily be exposed to any user or entity who has access to the logs.
 </details>
 
-**Result:** Not Scored
+**Result:** Manual
 
 **Audit:**
 Run the following command to find references to objects which use environment variables defined from secrets.
@@ -2536,13 +2552,13 @@ If possible, rewrite application code to read secrets from mounted secret files,
 
 
 #### 5.4.2
-Consider external secret storage (Not Scored)
+Consider external secret storage (Manual)
 <details>
 <summary>Rationale</summary>
 Kubernetes supports secrets as first-class objects, but care needs to be taken to ensure that access to secrets is carefully limited. Using an external secrets provider can ease the management of access to secrets, especially where secrests are used across both Kubernetes and non-Kubernetes environments.
 </details>
 
-**Result:** Not Scored
+**Result:** Manual
 
 **Audit:**
 Review your secrets management implementation.
@@ -2555,13 +2571,13 @@ Refer to the secrets management options offered by your cloud provider or a thir
 
 
 #### 5.5.1
-Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)
+Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)
 <details>
 <summary>Rationale</summary>
 Kubernetes supports plugging in provenance rules to accept or reject the images in your deployments. You could configure such rules to ensure that only approved images are deployed in the cluster.
 </details>
 
-**Result:** Not Scored
+**Result:** Manual
 
 **Audit:**
 Review the pod definitions in your cluster and verify that image provenance is configured as appropriate.
@@ -2571,7 +2587,7 @@ Follow the Kubernetes documentation and setup image provenance.
 
 
 ### 5.6 Omitted
-The v1.5.1 guide skips 5.6 and goes from 5.5 to 5.7. We are including it here merely for explanation.
+The v1.23 guide skips 5.6 and goes from 5.5 to 5.7. We are including it here merely for explanation.
 
 
 ### 5.7 General Policies
@@ -2579,13 +2595,13 @@ These policies relate to general cluster management topics, like namespace best 
 
 
 #### 5.7.1
-Create administrative boundaries between resources using namespaces (Not Scored)
+Create administrative boundaries between resources using namespaces (Manual)
 <details>
 <summary>Rationale</summary>
 Limiting the scope of user permissions can reduce the impact of mistakes or malicious activities. A Kubernetes namespace allows you to partition created resources into logically named groups. Resources created in one namespace can be hidden from other namespaces. By default, each resource created by a user in Kubernetes cluster runs in a default namespace, called default. You can create additional namespaces and attach resources and users to them. You can use Kubernetes Authorization plugins to create policies that segregate access to namespace resources between different users.
 </details>
 
-**Result:** Not Scored
+**Result:** Manual
 
 **Audit:**
 Run the below command and review the namespaces created in the cluster.
@@ -2601,13 +2617,13 @@ Follow the documentation and create namespaces for objects in your deployment as
 
 
 #### 5.7.2
-Ensure that the seccomp profile is set to `docker/default` in your pod definitions (Not Scored)
+Ensure that the seccomp profile is set to `docker/default` in your pod definitions (Manual)
 <details>
 <summary>Rationale</summary>
 Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. You should enable it to ensure that the workloads have restricted actions available within the container.
 </details>
 
-**Result:** Not Scored
+**Result:** Manual
 
 **Audit:**
 Review the pod definitions in your cluster. It should create a line as below:
@@ -2621,13 +2637,13 @@ annotations:
 Review the Kubernetes documentation and if needed, apply a relevant PodSecurityPolicy.
 
 #### 5.7.3
-Apply Security Context to Your Pods and Containers (Not Scored)
+Apply Security Context to Your Pods and Containers (Manual)
 <details>
 <summary>Rationale</summary>
 A security context defines the operating system security settings (uid, gid, capabilities, SELinux role, etc..) applied to a container. When designing your containers and pods, make sure that you configure the security context for your pods, containers, and volumes. A security context is a property defined in the deployment yaml. It controls the security parameters that will be assigned to the pod/container/volume. There are two levels of security context: pod level security context, and container level security context.
 </details>
 
-**Result:** Not Scored
+**Result:** Manual
 
 **Audit:**
 Review the pod definitions in your cluster and verify that you have security contexts defined as appropriate.
@@ -2637,13 +2653,13 @@ Follow the Kubernetes documentation and apply security contexts to your pods. Fo
 
 
 #### 5.7.4
-The default namespace should not be used (Scored)
+The default namespace should not be used (Manual)
 <details>
 <summary>Rationale</summary>
 Resources in a Kubernetes cluster should be segregated by namespace, to allow for security controls to be applied at that level and to make it easier to manage resources.
 </details>
 
-**Result:** Pass
+**Result:** Manual
 
 **Audit:**
 Run the below command on the master node.

--- a/docs/security/cis_self_assessment16.md
+++ b/docs/security/cis_self_assessment16.md
@@ -10,7 +10,7 @@ This document is a companion to the RKE2 security hardening guide. The hardening
 
 This guide is specific to the **v1.20** release line of RKE2 and the **v1.6.1** release of the CIS Kubernetes Benchmark.
 
-For more detail about each control, including more detailed descriptions and remediations for failing tests, you can refer to the corresponding section of the CIS Kubernetes Benchmark v1.5. You can download the benchmark after logging in to [CISecurity.org]( https://www.cisecurity.org/benchmark/kubernetes/).
+For more detail about each control, including more detailed descriptions and remediations for failing tests, you can refer to the corresponding section of the CIS Kubernetes Benchmark v1.6. You can download the benchmark after logging in to [CISecurity.org]( https://www.cisecurity.org/benchmark/kubernetes/).
 
 #### Testing controls methodology
 

--- a/docs/security/hardening_guide.md
+++ b/docs/security/hardening_guide.md
@@ -2,104 +2,264 @@
 title: CIS Hardening Guide
 ---
 
-This document provides prescriptive guidance for hardening a production installation of RKE2. It outlines the configurations and controls required to address Kubernetes benchmark controls from the Center for Information Security (CIS).
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-For more detail about evaluating a hardened cluster against the official CIS benchmark, refer to the CIS Benchmark Rancher Self-Assessment Guide [v1.5](cis_self_assessment15.md) or [v1.6](cis_self_assessment16.md).
+This document provides prescriptive guidance for hardening a production installation of RKE2. It outlines the configurations and controls required to address Kubernetes benchmark controls from the Center for Internet Security (CIS).
+
+For more details about evaluating a hardened cluster against the official CIS benchmark, refer to the CIS Benchmark [Self-Assessment Guide v1.23](cis_self_assessment123.md), or [Self-Assessment Guide v1.6](cis_self_assessment16.md) for RKE2 versions prior to v1.25.
 
 RKE2 is designed to be "hardened by default" and pass the majority of the Kubernetes CIS controls without modification. There are a few notable exceptions to this that require manual intervention to fully pass the CIS Benchmark:
 
-1. RKE2 will not modify the host operating system. Therefore, you, the operator, must make a few Host-level modifications.
-2. Certain CIS policy controls for PodSecurityPolicies and NetworkPolicies will restrict the functionality of this cluster. You must opt into having RKE2 configuring these out of the box.
+1. RKE2 will not modify the host operating system. Therefore, you, the operator, must make a few host-level modifications.
+2. Certain CIS controls for Network Policies and Pod Security Standards (or Pod Security Policies (PSP) on RKE2 versions prior to v1.25) will restrict the functionality of the cluster. You must opt into having RKE2 configure these for you.
 
-To help ensure these above requirements are met, RKE2 can be started with the `profile` flag set to `cis-1.5` or `cis-1.6`. This flag generally does two things:
+To help ensure these above requirements are met, RKE2 can be started with the `profile` flag set to `cis-1.23`, or `cis-1.6`. This flag generally does the following:
+
+<Tabs>
+<TabItem value='v1.25 and Newer' default>
 
 1. Checks that host-level requirements have been met. If they haven't, RKE2 will exit with a fatal error describing the unmet requirements.
-2. Configures runtime Pod Security Policies and Network Policies that allow the cluster to pass associated controls.
 
-> **Note:** The profile's flag only valid values are `cis-1.5` or `cis-1.6`. It accepts a string value to allow for other profiles in the future.
+2. Configures Pod Security Standards of restricted mode to the whole cluster with exception of the kube-system namespace to allow system pods to run without restrictions, for more information about the pod security standards please refer to the [official documentation](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 
-The following section outlines the specific actions that are taken when the `profile` flag is set to `cis-1.5` or `cis-1.6`.
+3. Apply network policies that allow the cluster to pass associated controls.
 
-## Host-level Requirements
+:::note
+The only valid value for the profile flag is `cis-1.23`. It accepts a string value to allow for other profiles in the future.
+:::
 
-There are two areas of Host-level requirements: kernel parameters and etcd process/directory configuration. These are outlined in this section.
+</TabItem>
+
+<TabItem value='v1.24 and Older'>
+
+1. Checks that host-level requirements have been met. If they haven't, RKE2 will exit with a fatal error describing the unmet requirements.
+2. Configures runtime pod security policies and network policies that allow the cluster to pass associated controls.
+
+:::note
+The only valid values for the profile flag are `cis-1.5` or `cis-1.6`.
+:::
+
+:::note
+The self-assessment guide for CIS v1.5 (`cis-1.5`) was removed from this documentation, since this version is applicable only to Kubernetes v1.15 that is not supported anymore. The profile, however, is still available in RKE2.
+:::
+
+</TabItem>
+</Tabs>
+
+The following section outlines the specific actions that are taken when the `profile` flag is set to `cis-1.6` or `cis-1.23`.
+
+## Host-level requirements
+
+There are two areas of host-level requirements: kernel parameters and etcd process/directory configuration. These are outlined in this section.
 
 ### Ensure `protect-kernel-defaults` is set
+
 This is a kubelet flag that will cause the kubelet to exit if the required kernel parameters are unset or are set to values that are different from the kubelet's defaults.
 
-When the `profile` flag is set, RKE2 will set the flag to true.
+When the `profile` flag is set, RKE2 will set the flag to `true`.
 
-> **Note:** `protect-kernel-defaults` is exposed a top-level flag for RKE2. If you have set `profile` to "cis-1.x" and `protect-kernel-defaults` to false explicitly, RKE2 will exit with an error.
+!!! note
+    `protect-kernel-defaults` is exposed as a top-level flag for RKE2. If you have set `profile` to "cis-1.x" and `protect-kernel-defaults` to false explicitly, RKE2 will exit with an error.
 
 RKE2 will also check the same kernel parameters that the kubelet does and exit with an error following the same rules as the kubelet. This is done as a convenience to help the operator more quickly and easily identify what kernel parameters are violating the kubelet defaults.
 
-### Ensure etcd is started properly
-The CIS Benchmark requires that the etcd data directory be owned by the `etcd` user and group. This implicitly requires the etcd process to be ran as the host-level `etcd` user. To achieve this, RKE2 takes several steps when started with the cis-1.5 profile:
+### Ensure etcd is configured properly
+
+The CIS Benchmark requires that the etcd data directory be owned by the `etcd` user and group. This implicitly requires the etcd process to be ran as the host-level `etcd` user. To achieve this, RKE2 takes several steps when started with a valid "cis-1.x" profile:
 
 1. Check that the `etcd` user and group exists on the host. If they don't, exit with an error.
 2. Create etcd's data directory with `etcd` as the user and group owner.
-3. Ensure the etcd process is ran as the `etcd` user and group by setting the etcd static pod's SecurityContext appropriately.
+3. Ensure the etcd process is ran as the `etcd` user and group by setting the etcd static pod's `SecurityContext` appropriately.
 
 ### Setting up hosts
+
 This section gives you the commands necessary to configure your host to meet the above requirements.
 
 #### Set kernel parameters
-When RKE2 is installed, it creates a sysctl config file to set the required parameters appropriately.
-However, it does not automatically configure the Host to use this configuration. You must do this manually.
-The location of the config file depends on the installation method used.
 
-If RKE2 was installed via RPM, YUM, or DNF (the default on OSes that use RPMs, such as CentOS), run the following command(s):
+When RKE2 is installed, it creates a sysctl config file to set the required parameters appropriately. However, it does not automatically configures the host to use this configuration. You must do this manually. The location of the config file depends on the installation method used.
+
+If RKE2 was installed via RPM, YUM, or DNF (the default on OSes that use RPMs, such as CentOS), run the following commands:
+
 ```bash
 sudo cp -f /usr/share/rke2/rke2-cis-sysctl.conf /etc/sysctl.d/60-rke2-cis.conf
 sudo systemctl restart systemd-sysctl
 ```
 
-If RKE2 was installed via the tarball (the default on OSes that do not use RPMs, such as Ubuntu), run the following command:
+If RKE2 was installed via the tarball (the default on OSes that do not use RPMs, such as Ubuntu), run the following commands:
+
 ```bash
 sudo cp -f /usr/local/share/rke2/rke2-cis-sysctl.conf /etc/sysctl.d/60-rke2-cis.conf
 sudo systemctl restart systemd-sysctl
 ```
 
-If your system lacks the `systemd-sysctl.service` and/or the `/etc/sysctl.d` directory you will want to make sure the
-sysctls are applied at boot by running the following command during start-up:
+If your system lacks the `systemd-sysctl.service` and/or the `/etc/sysctl.d` directory, you will want to make sure the sysctls are applied at boot by running the following command during start-up:
+
 ```bash
-sysctl -p /usr/local/share/rke2/rke2-cis-sysctl.conf
+sudo sysctl -p /usr/local/share/rke2/rke2-cis-sysctl.conf
 ```
 
-Please perform this step only on fresh installations, before actually using RKE2 to deploy Kubernetes. Many
-Kubernetes components, including CNI plugins, are setting up their own sysctls. Restarting the
-`systemd-sysctl` service on a running Kubernetes cluster can result in unexpected side-effects.
+Please perform this step only on fresh installations, before actually using RKE2 to deploy Kubernetes. Many Kubernetes components, including CNI plugins, set up their own sysctls. Restarting the `systemd-sysctl` service on a running Kubernetes cluster can result in unexpected side-effects.
 
 #### Create the etcd user
 On some Linux distributions, the `useradd` command will not create a group. The `-U` flag is included below to account for that. This flag tells `useradd` to create a group with the same name as the user.
- 
+
 ```bash
-useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U
+sudo useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U
 ```
 
-## Kubernetes Runtime Requirements
+## Kubernetes runtime requirements
 
 The runtime requirements to pass the CIS Benchmark are centered around pod security and network policies. These are outlined in this section.
 
-### PodSecurityPolicies
+### `PodSecurityPolicies`
 
-RKE2 always runs with the PodSecurityPolicy admission controller turned on. However, when it is **not** started with the cis-1.5 profile, RKE2 will put an unrestricted policy in place that allows Kubernetes to run as though the PodSecurityPolicy admission controller was not enabled.
+RKE2 always runs with the `PodSecurityPolicy` admission controller turned on. However, when it is **not** started with a valid "cis-1.x" profile, RKE2 will put an unrestricted policy in place that allows Kubernetes to run as though the `PodSecurityPolicy` admission controller was not enabled.
 
-When ran with the cis-1.5 profile, RKE2 will put a much more restrictive set of policies in place. These policies meet the requirements outlined in section 5.2 of the CIS Benchmark.
+When ran with a valid "cis-1.x" profile, RKE2 will put a much more restrictive set of policies in place. These policies meet the requirements outlined in section 5.2 of the CIS Benchmark.
 
-> **Note:** The Kubernetes control plane components and critical additions such as CNI, DNS, and Ingress are ran as pods in the `kube-system` namespace. Therefore, this namespace will have a policy that is less restrictive so that these components can run properly.
+!!! note
+    The Kubernetes control plane components and critical additions such as CNI, DNS, and Ingress are ran as pods in the `kube-system` namespace. Therefore, this namespace will have a policy that is less restrictive so that these components can run properly.
 
-### NetworkPolicies
+### `NetworkPolicies`
 
-When ran with the cis-1.5 profile, RKE2 will put NetworkPolicies in place that passes the CIS Benchmark for Kubernetes's built-in namespaces. These namespaces are: `kube-system`, `kube-public`, `kube-node-lease`, and `default`.
+When ran with a valid "cis-1.x" profile, RKE2 will put `NetworkPolicies` in place that passes the CIS Benchmark for Kubernetes' built-in namespaces. These namespaces are: `kube-system`, `kube-public`, `kube-node-lease`, and `default`.
 
-The NetworkPolicy used will only allow pods within the same namespace to talk to each other. The notable exception to this is that it allows DNS requests to be resolved.
+The `NetworkPolicy` used will only allow pods within the same namespace to talk to each other. The notable exception to this is that it allows DNS requests to be resolved.
 
-> **Note:** Operators must manage network policies as normal for additional namespaces that are created.
+!!! note
+    Operators must manage network policies as normal for additional namespaces that are created.
 
-## Known Issues
+### Configure `default` service account
+
+**Set `automountServiceAccountToken` to `false` for `default` service accounts**
+
+Kubernetes provides a `default` service account which is used by cluster workloads where no specific service account is assigned to the pod. Where access to the Kubernetes API from a pod is required, a specific service account should be created for that pod, and rights granted to that service account. The `default` service account should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
+
+For each namespace including `default` and `kube-system` on a standard RKE2 install, the `default` service account must include this value:
+
+```yaml
+automountServiceAccountToken: false
+```
+
+For namespaces created by the cluster operator, the following script and configuration file can be used to configure the `default` service account.
+
+The configuration below must be saved to a file called `account_update.yaml`.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false
+```
+
+Create a bash script file called `account_update.sh`. Be sure to `sudo chmod +x account_update.sh` so the script has execute permissions.
+
+```bash
+#!/bin/bash -e
+
+for namespace in $(kubectl get namespaces -A -o=jsonpath="{.items[*]['metadata.name']}"); do
+  echo -n "Patching namespace $namespace - "
+  kubectl patch serviceaccount default -n ${namespace} -p "$(cat account_update.yaml)"
+done
+```
+
+Execute this script to apply the `account_update.yaml` configuration to `default` service account in all namespaces.
+
+### API Server audit configuration
+
+CIS requirements 1.2.22 to 1.2.25 are related to configuring audit logs for the API Server. When RKE2 is started with the `profile` flag set, it will automatically configure hardened `--audit-log-` parameters in the API Server to pass those CIS checks.
+
+RKE2's default audit policy is configured to not log requests in the API Server. This is done to allow cluster operators flexibility to customize an audit policy that suits their auditing requirements and needs, as these are specific to each users' environment and policies.
+
+A default audit policy is created by RKE2 when started with the `profile` flag set. The policy is defined in `/etc/rancher/rke2/audit-policy.yaml`.
+
+```yaml
+apiVersion: audit.k8s.io/v1
+kind: Policy
+metadata:
+  creationTimestamp: null
+rules:
+- level: None
+```
+
+To start logging requests to the API Server, at least `level` parameter must be modified, for example, to `Metadata`. Detailed information about policy configuration for the API server can be found in the Kubernetes [documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/).
+
+After adapting the audit policy, RKE2 must be restarted to load the new configuration.
+
+```shell
+sudo systemctl restart rke2-server.service
+```
+
+API Server audit logs will be written to `/var/lib/rancher/rke2/server/logs/audit.log`.
+
+## Known issues
+
 The following are controls that RKE2 currently does not pass. Each gap will be explained and whether it can be passed through manual operator intervention or if it will be addressed in a future release.
+
+### Control  1.1.12
+Ensure that the etcd data directory ownership is set to `etcd:etcd`.
+
+**Rationale**
+etcd is a highly-available key-value store used by Kubernetes deployments for persistent storage of all of its REST API objects. This data directory should be protected from any unauthorized reads or writes. It should be owned by `etcd:etcd`.
+
+**Remediation**
+This can be remediated by creating an `etcd` user and group as described above.
+
+### Control 5.1.5
+Ensure that default service accounts are not actively used
+
+**Rationale** Kubernetes provides a `default` service account which is used by cluster workloads where no specific service account is assigned to the pod.
+
+Where access to the Kubernetes API from a pod is required, a specific service account should be created for that pod, and rights granted to that service account.
+
+The `default` service account should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
+
+This can be remediated by updating the `automountServiceAccountToken` field to `false` for the `default` service account in each namespace.
+
+**Remediation**
+You can manually update this field on service accounts in your cluster to pass the control as described above.
+
+### Control 5.3.2
+Ensure that all Namespaces have Network Policies defined
+
+**Rationale**
+Running different applications on the same Kubernetes cluster creates a risk of one compromised application attacking a neighboring application. Network segmentation is important to ensure that containers can communicate only with those they are supposed to. A network policy is a specification of how selections of pods are allowed to communicate with each other and other network endpoints.
+
+Network Policies are namespace scoped. When a network policy is introduced to a given namespace, all traffic not allowed by the policy is denied. However, if there are no network policies in a namespace all traffic will be allowed into and out of the pods in that namespace.
+
+**Remediation**
+This can be remediated by starting RKE2 with the `profile` flag set in the configuration file. An example can be found below.
+
+## RKE2 configuration
+
+<Tabs>
+<TabItem value='v1.25 and Newer' default>
+
+Below is the minimum necessary configuration needed for hardening RKE2 to pass CIS v1.23 hardened profile `rke2-cis-1.23-profile-hardened` available in Rancher.
+
+```yaml
+secrets-encryption: "true"
+profile: "cis-1.23"           # CIS 4.2.6, 5.2.1, 5.2.8, 5.2.9, 5.3.2
+```
+
+</TabItem>
+<TabItem value='v1.24 and Older'>
+
+Below is the minimum necessary configuration needed for hardening RKE2 to pass CIS v1.6 hardened profile `rke2-cis-1.6-profile-hardened` available in Rancher.
+
+```yaml
+secrets-encryption: "true"
+profile: "cis-1.6"           # CIS 4.2.6, 5.2.1, 5.2.8, 5.2.9, 5.3.2
+```
+
+</TabItem>
+</Tabs>
+
+The configuration file must be named `config.yaml` and placed in `/etc/rancher/rke2`. The directory needs to be created prior to installing RKE2.
 
 ## Conclusion
 
-If you have followed this guide, your RKE2 cluster will be configured to pass the CIS Kubernetes Benchmark. You can review our CIS Benchmark Self-Assessment Guide [v1.5](cis_self_assessment15.md) or [v1.6](cis_self_assessment16.md) to understand how we verified each of the benchmarks and how you can do the same on your cluster.
+If you have followed this guide, your RKE2 cluster will be configured to pass the CIS Kubernetes Benchmark. You can review our CIS Benchmark Self-Assessment Guide [v1.6](cis_self_assessment16.md) or [v1.23](cis_self_assessment123.md) to understand how we verified each of the benchmarks and how you can do the same on your cluster.

--- a/docs/security/hardening_guide.md
+++ b/docs/security/hardening_guide.md
@@ -66,11 +66,11 @@ RKE2 will also check the same kernel parameters that the kubelet does and exit w
 
 ### Ensure etcd is configured properly
 
-The CIS Benchmark requires that the etcd data directory be owned by the `etcd` user and group. This implicitly requires the etcd process to be ran as the host-level `etcd` user. To achieve this, RKE2 takes several steps when started with a valid "cis-1.x" profile:
+The CIS Benchmark requires that the etcd data directory be owned by the `etcd` user and group. This implicitly requires the etcd process run as the host-level `etcd` user. To achieve this, RKE2 takes several steps when started with a valid "cis-1.x" profile:
 
 1. Check that the `etcd` user and group exists on the host. If they don't, exit with an error.
 2. Create etcd's data directory with `etcd` as the user and group owner.
-3. Ensure the etcd process is ran as the `etcd` user and group by setting the etcd static pod's `SecurityContext` appropriately.
+3. Ensure the etcd process is run as the `etcd` user and group by setting the etcd static pod's `SecurityContext` appropriately.
 
 ### Setting up hosts
 
@@ -78,7 +78,7 @@ This section gives you the commands necessary to configure your host to meet the
 
 #### Set kernel parameters
 
-When RKE2 is installed, it creates a sysctl config file to set the required parameters appropriately. However, it does not automatically configures the host to use this configuration. You must do this manually. The location of the config file depends on the installation method used.
+When RKE2 is installed, it creates a sysctl config file to set the required parameters appropriately. However, it does not automatically configure the host to use this configuration. You must do this manually. The location of the config file depends on the installation method used.
 
 If RKE2 was installed via RPM, YUM, or DNF (the default on OSes that use RPMs, such as CentOS), run the following commands:
 

--- a/docs/security/pod_security_standards.md
+++ b/docs/security/pod_security_standards.md
@@ -1,0 +1,130 @@
+---
+title: Default Pod Security Standards
+---
+
+This document describes how RKE2 configures `PodSecurityStandards` and `NetworkPolicies` in order to be secure-by-default while also providing operators with maximum configuration flexibility.
+
+:::caution Version Gate
+This document applies to RKE2 v1.25 and higher, which uses Pod Security Standards. For information on Pod Security Policies present in prior releases, please refer to the [Default Policies Documentation](./pod_security_policies.md).
+:::
+
+#### Pod Security Standards
+
+Starting from Kubernetes version v1.25.0, Pod Security Policies (PSP) are totally removed from Kubernetes, and replaced by [Pod Security Admission (PSA)](https://kubernetes.io/docs/concepts/security/pod-security-admission/). A default Pod Security Admission config file will be added to the cluster upon startup as follows:
+
+* If running with the `--profile=cis-1.23` option, RKE2 will apply a restricted pod security standard via a configuration file which will enforce `restricted` mode throughout the cluster with an exception to the `kube-system` and `cis-operator-system` namespaces to ensure successful operation of system pods.
+
+* If running without the `--profile=cis-1.23` option, RKE2 will apply a nonrestricted pod security standard via a configuration file which will enforce `privileged` mode throughout the cluster which allows a completely unrestricted mode to all pods in the cluster.
+
+RKE2 will put this configuration file at `/etc/rancher/rke2/rke2-pss.yaml`, the content of the configuration file varries according to the cis mode which you started rke2:
+
+**CIS Mode**
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1beta1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: "restricted"
+      enforce-version: "latest"
+      audit: "restricted"
+      audit-version: "latest"
+      warn: "restricted"
+      warn-version: "latest"
+    exemptions:
+      usernames: []
+      runtimeClasses: []
+      namespaces: [kube-system, cis-operator-system]
+```
+
+**Non CIS Mode**
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1beta1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: "privileged"
+      enforce-version: "latest"
+    exemptions:
+      usernames: []
+      runtimeClasses: []
+      namespaces: []
+```
+
+After placing this configuration file, rke2 will start the kube-apiserver with the following flag `--admission-control-config-file` which will be set to the path of the PSA config file.
+
+If you want to override the default pod security standard configuration file, you can pass `pod-security-admission-config-file: <path-to-custom-psa-config-file>` to the RKE2 config file.
+
+#### Network Policies
+
+When RKE2 is run with the `profile: cis-1.23` parameter, it will apply 2 network policies to the `kube-system`, `kube-public`, and `default` namespaces and applies associated annotations. The same logic applies to these policies and annotations as the PSPs. On start, the annotations for each namespace are checked for existence and if they exist, RKE2 takes no action. If the annotation doesn't exist, RKE2 checks to see if the policy exists and if it does, recreates it.
+
+The first policy applied is to restrict network traffic to only the namespace itself. See below.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  managedFields:
+  - apiVersion: networking.k8s.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:spec:
+        f:ingress: {}
+        f:policyTypes: {}
+  name: default-network-policy
+  namespace: default
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+  policyTypes:
+  - Ingress
+```
+
+The second policy applied is to the `kube-system` namespace and allows for DNS traffic. See below.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  managedFields:
+  - apiVersion: networking.k8s.io/v1
+    fieldsV1:
+      f:spec:
+        f:ingress: {}
+        f:podSelector:
+          f:matchLabels:
+        f:policyTypes: {}
+  name: default-network-dns-policy
+  namespace: kube-system
+spec:
+  ingress:
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+  podSelector:
+    matchLabels:
+  policyTypes:
+  - Ingress
+```
+
+RKE2 applies the `default-network-policy` policy and `np.rke2.io` annotation to all built-in namespaces. The `kube-system` namespace additionally gets the `default-network-dns-policy` policy and `np.rke2.io/dns` annotation applied to it.
+
+To view the network policies currently deployed on your system, run the below command:
+
+```bash
+kubectl get networkpolicies -A
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,10 +33,11 @@ module.exports = {
       items:[
         'security/about_hardened_images',
         'security/hardening_guide',
-        'security/cis_self_assessment15',
         'security/cis_self_assessment16',
+        'security/cis_self_assessment123',
         'security/fips_support',
-        'security/policies',
+        'security/pod_security_policies',
+        'security/pod_security_standards',
         'security/selinux',
         'security/secrets_encryption',
       ],


### PR DESCRIPTION
Copy over work from https://github.com/rancher/rke2/pull/3360 into the new docs site, with minor changes to match the "docusaurus" style guides.

Signed-off-by: Derek Nola <derek.nola@suse.com>