### PR TITLE
Fix dead link in backup_restore.md

### DIFF
--- a/docs/backup_restore.md
+++ b/docs/backup_restore.md
@@ -18,7 +18,7 @@ To configure the snapshot interval or the number of retained snapshots, refer to
 
 In RKE2, snapshots are stored on each etcd node. If you have multiple etcd or etcd + control-plane nodes, you will have multiple copies of local etcd snapshots.
 
-You can take a snapshot manually while RKE2 is running with the `etcd-snapshot` subcommand. For example: `rke2 etcd-snapshot save --name pre-upgrade-snapshot`. See the full list of etcd-snapshot subcommands at the [subcommands page](https://docs.rke2.io/subcommands/#etcd-snapshot)
+You can take a snapshot manually while RKE2 is running with the `etcd-snapshot` subcommand. For example: `rke2 etcd-snapshot save --name pre-upgrade-snapshot`. See the full list of etcd-snapshot subcommands at the [subcommands page](https://docs.rke2.io/reference/subcommands#etcd-snapshot)
 
 ## Cluster Reset
 


### PR DESCRIPTION
"Subcommands" page link was dead, updated it to the correct one