### PR TITLE
Update http proxy configuration docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -43,12 +43,12 @@ Add the necessary `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` variables to the en
 - `/etc/default/rke2-server`
 - `/etc/default/rke2-agent`
 
-The `NO_PROXY` variable must include your internal networks, as well as the cluster pod and service IP ranges.
+RKE2 will automatically add the cluster internal Pod and Service IP ranges and cluster DNS domain to the list of `NO_PROXY` entries. You should ensure that the IP address ranges used by the Kubernetes nodes themselves (i.e. the public and private IPs of the nodes) are included in the `NO_PROXY` list, or that the nodes can be reached through the proxy.
 
 ```
 HTTP_PROXY=http://your-proxy.example.com:8888
 HTTPS_PROXY=http://your-proxy.example.com:8888
-NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 ```
 
 If you want to configure the proxy settings for containerd without affecting RKE2 and the Kubelet, you can prefix the variables with `CONTAINERD_`:
@@ -56,7 +56,7 @@ If you want to configure the proxy settings for containerd without affecting RKE
 ```
 CONTAINERD_HTTP_PROXY=http://your-proxy.example.com:8888
 CONTAINERD_HTTPS_PROXY=http://your-proxy.example.com:8888
-CONTAINERD_NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+CONTAINERD_NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 ```
 
 ## Node Labels and Taints


### PR DESCRIPTION
RKE2 automatically adds the cluster and service ip ranges as well as the cluster dns domain to NO_PROXY. It's not necessary to configure this manually.

This also has been documented for K3s in https://github.com/k3s-io/docs/pull/70.

See also the discussion in: https://github.com/k3s-io/docs/pull/70#discussion_r1067267161