### PR TITLE
Bump os matrix

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -19,7 +19,8 @@ RKE2 has been tested and validated on the following operating systems, and their
 | - | - |
 | Ubuntu | 18.04, 20.04, 22.04 | 
 | CentOS/RHEL | 7.8 |
-| Rocky/RHEL | 8.5, 9.0 | 
+| Rocky/RHEL | 8.5, 9.1 | 
+| Oracle Linux | 8.7 |
 | SLES | 15 SP3, SP4 |
 | OpenSUSE, SLE Micro | 5.1, 5.2, 5.3 |
 

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -22,7 +22,7 @@ RKE2 has been tested and validated on the following operating systems, and their
 | Rocky/RHEL | 8.5, 9.1 | 
 | Oracle Linux | 8.7 |
 | SLES | 15 SP3, SP4 |
-| OpenSUSE, SLE Micro | 5.1, 5.2, 5.3 |
+| OpenSUSE, SLE Micro | 5.1, 5.2, 5.3, 5.4 |
 
 ### Windows
 :::caution Version Gate


### PR DESCRIPTION
Include recently validated Oracle Linux 8.7 and Rocky 9.1