### PR TITLE
Add docs for shipped CLI tools and log locations

### DIFF
--- a/docs/reference/cli_tools.md
+++ b/docs/reference/cli_tools.md
@@ -1,0 +1,31 @@
+---
+title: "CLI Tools"
+---
+
+RKE2 ships several CLI tools to help with accessing and debugging the cluster. On startup they are extracted to `/var/lib/rancher/rke2/bin`.
+
+## kubectl
+
+An admin kubeconfig is generated at `/etc/rancher/rke2/rke2.yaml`.
+
+Example:
+
+```
+export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+/var/lib/rancher/rke2/bin/kubectl get nodes
+```
+
+## Containerd
+
+RKE2 ships with `ctr` and `crictl`. The Containerd socket is located at `/run/k3s/containerd/containerd.sock`.
+
+Examples:
+
+```
+/var/lib/rancher/rke2/bin/ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io container ls
+```
+
+```
+export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+/var/lib/rancher/rke2/bin/crictl ps
+```

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -16,7 +16,7 @@ Logs from each Kubernetes Pod can be accessed with `kubectl`:
 /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml logs -n kube-system -l component=kube-apiserver
 ```
 
-Logs from each container can be accessed with `crictl`:
+Logs from each container are written to `/var/log/pods` or can be accessed with `crictl`:
 
 ```
 export CONTAINER_RUNTIME_ENDPOINT=unix:///run/k3s/containerd/containerd.sock

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -1,0 +1,26 @@
+---
+title: "Logging"
+---
+
+When running with systemd, the main RKE2 logs will be created in `/var/log/syslog` and viewed using `journalctl -u rke2-server` or `journalctl -u rke2-agent`.
+
+The Containerd logs are written to `/var/lib/rancher/rke2/agent/containerd/containerd.log`.
+
+The kubelet logs are written to `/var/lib/rancher/rke2/agent/logs/kubelet.log`.
+
+Etcd and the Kubernetes control-plane components run as static Pods in the `kube-system` namespace.
+
+Logs from each Kubernetes Pod can be accessed with `kubectl`:
+
+```
+/var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml logs -n kube-system -l component=kube-apiserver
+```
+
+Logs from each container can be accessed with `crictl`:
+
+```
+# list running containers
+/var/lib/rancher/rke2/bin/crictl --runtime-endpoint unix:///run/k3s/containerd/containerd.sock ps
+# get logs from container by container id
+/var/lib/rancher/rke2/bin/crictl --runtime-endpoint unix:///run/k3s/containerd/containerd.sock logs <container_id>
+```

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -19,8 +19,9 @@ Logs from each Kubernetes Pod can be accessed with `kubectl`:
 Logs from each container can be accessed with `crictl`:
 
 ```
+export CONTAINER_RUNTIME_ENDPOINT=unix:///run/k3s/containerd/containerd.sock
 # list running containers
-/var/lib/rancher/rke2/bin/crictl --runtime-endpoint unix:///run/k3s/containerd/containerd.sock ps
+/var/lib/rancher/rke2/bin/crictl ps
 # get logs from container by container id
-/var/lib/rancher/rke2/bin/crictl --runtime-endpoint unix:///run/k3s/containerd/containerd.sock logs <container_id>
+/var/lib/rancher/rke2/bin/crictl logs <container_id>
 ```

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -2,7 +2,7 @@
 title: "Logging"
 ---
 
-When running with systemd, the main RKE2 logs will be created in `/var/log/syslog` and viewed using `journalctl -u rke2-server` or `journalctl -u rke2-agent`.
+When running with systemd, logs are sent to journald and can be viewed using `journalctl -u rke2-server` or `journalctl -u rke2-agent`. Some systemd configurations may also write combined logs to `/var/log/syslog`, in which case the rke2 logs will also be available there.
 
 The Containerd logs are written to `/var/lib/rancher/rke2/agent/containerd/containerd.log`.
 


### PR DESCRIPTION
This adds documentation pages for

* List of shipped CLI tools (kubectl, ctr, crictl, etcdctl) and examples how to use them
* Locations of the various logs

Documenting this will help with debugging RKE2.

The information is taken from this excellent Gist https://gist.github.com/superseb/3b78f47989e0dbc1295486c186e944bf.