### PR TITLE
Add link to RKE2 charts repository to Customizing Packaged Helm Charts

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -78,3 +78,5 @@ spec:
     image: coredns/coredns
     imageTag: v1.7.1
 ```
+
+You can find all the packaged Helm charts including their documentation and default values in the [RKE2 charts repository](https://github.com/rancher/rke2-charts/tree/main/charts).


### PR DESCRIPTION
This adds a link to the RKE2 charts repository to the "Customizing Packaged Helm Charts" section to make it easier to find out which Helm charts can be customized with which values.