### PR TITLE
Add `rke2-agent` restart step to Certificate Rotation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -18,6 +18,10 @@ systemctl stop rke2-server
 rke2 certificate rotate
 systemctl start rke2-server
 ```
+To renew agent certificates, restart rke2-agent in agent nodes. Agent certificates are renewed every time the agent starts.
+```sh
+systemctl restart rke2-agent
+```
 It is also possible to rotate an individual service by passing the `--service` flag, for example: `rke2 certificate rotate --service api-server`. See the [certificate subcommand](./reference/subcommands.md#certificate) for more details.
 
 ## Auto-Deploying Manifests


### PR DESCRIPTION
We need to restart `rke2-agent` to rotate certificates of agent nodes.