### PR TITLE
Update network_options.md with better IPv6 examples and a caution

### DIFF
--- a/docs/install/network_options.md
+++ b/docs/install/network_options.md
@@ -161,7 +161,7 @@ Each CNI plugin requires a different configuration for dual-stack:
 Canal automatically detects the RKE2 configuration for dual-stack and does not need any extra configuration. Dual-stack is currently not supported in the windows installations of RKE2.
 
 :::note
-When choosing a netmask for cluster-cidr, please note that `node-cidr-mask-size-ipv6` has a default value of /64 - thus this need to be changed if you choose a netmask of /64 or smaller for `cluster-cidr`
+When choosing a netmask for cluster-cidr, please note that `node-cidr-mask-size-ipv6` has a default value of /64 - thus this need to be changed if you choose a netmask of /64 or smaller for `cluster-cidr`. This is accomplished by adding `--node-cidr-mask-size-ipv6=xx"` as an argument to the `kube-controller-manager` manifest.
 :::
 
 </TabItem>
@@ -170,7 +170,7 @@ When choosing a netmask for cluster-cidr, please note that `node-cidr-mask-size-
 Cilium automatically detects the RKE2 configuration for dual-stack and does not need any extra configuration.
 
 :::note
-When choosing a netmask for cluster-cidr, please note that `node-cidr-mask-size-ipv6` has a default value of /64 - thus this need to be changed if you choose a netmask of /64 or smaller for `cluster-cidr`
+When choosing a netmask for cluster-cidr, please note that `node-cidr-mask-size-ipv6` has a default value of /64 - thus this need to be changed if you choose a netmask of /64 or smaller for `cluster-cidr` This is accomplished by adding `--node-cidr-mask-size-ipv6=xx"` as an argument to the `kube-controller-manager` manifest.
 :::
 
 </TabItem>

--- a/docs/install/network_options.md
+++ b/docs/install/network_options.md
@@ -150,7 +150,7 @@ service-cidr: "10.43.0.0/16,2001:db8:cafe:100::/112"
 :::caution
 The IPv6 addresses above are reserved for documentation/examples, and should not be used. It's advised to use ULA IPv6 addresses as defined in RFC [4193](https://www.rfc-editor.org/rfc/rfc4193.txt). Tips: Use a [ULA generator](https://cd34.com/rfc4193/).
 
-The cluster-cidr must have a netmask of /56, and the service-cidr must be /108 or smaller.
+The netmask for `service-cidr` must be /108 or smaller.
 :::
 
 Each CNI plugin requires a different configuration for dual-stack:
@@ -160,10 +160,18 @@ Each CNI plugin requires a different configuration for dual-stack:
 
 Canal automatically detects the RKE2 configuration for dual-stack and does not need any extra configuration. Dual-stack is currently not supported in the windows installations of RKE2.
 
+:::note
+When choosing a netmask for cluster-cidr, please note that `node-cidr-mask-size-ipv6` has a default value of /64 - thus this need to be changed if you choose a netmask of /64 or smaller for `cluster-cidr`
+:::
+
 </TabItem>
 <TabItem value="Cilium CNI plugin" default>
 
 Cilium automatically detects the RKE2 configuration for dual-stack and does not need any extra configuration.
+
+:::note
+When choosing a netmask for cluster-cidr, please note that `node-cidr-mask-size-ipv6` has a default value of /64 - thus this need to be changed if you choose a netmask of /64 or smaller for `cluster-cidr`
+:::
 
 </TabItem>
 <TabItem value="Calico CNI plugin" default>

--- a/docs/install/network_options.md
+++ b/docs/install/network_options.md
@@ -144,9 +144,14 @@ IPv4/IPv6 dual-stack networking enables the allocation of both IPv4 and IPv6 add
 
 ```yaml
 #/etc/rancher/rke2/config.yaml
-cluster-cidr: "10.42.0.0/16,2001:cafe:42:0::/56"
-service-cidr: "10.43.0.0/16,2001:cafe:42:1::/112"
+cluster-cidr: "10.42.0.0/16,2001:db8:cafe:0::/56"
+service-cidr: "10.43.0.0/16,2001:db8:cafe:100::/112"
 ```
+:::caution
+The IPv6 addresses above are reserved for documentation/examples, and should not be used. It's advised to use ULA IPv6 addresses as defined in RFC [4193](https://www.rfc-editor.org/rfc/rfc4193.txt). Tips: Use a [ULA generator](https://cd34.com/rfc4193/).
+
+The cluster-cidr must have a netmask of /56, and the service-cidr must be /108 or smaller.
+:::
 
 Each CNI plugin requires a different configuration for dual-stack:
 


### PR DESCRIPTION
The documentation does not specify the size of IPv6 netmask, which may be a source of confusion and errors.
In addition, the documentation uses global unique addresses which are/will be assigned, which is bad practice. The preferred way is to use ULA (RFC 4193)