### PR TITLE
add pod-security-admission-config-file parameters to server configuration

### DIFF
--- a/docs/reference/server_config.md
+++ b/docs/reference/server_config.md
@@ -88,6 +88,7 @@ OPTIONS:
    --cloud-provider-name value                   (cloud provider) Cloud provider name [$RKE2_CLOUD_PROVIDER_NAME]
    --cloud-provider-config value                 (cloud provider) Cloud provider configuration file path [$RKE2_CLOUD_PROVIDER_CONFIG]
    --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.6, cis-1.23 ) [$RKE2_CIS_PROFILE]
+   --pod-security-admission-config-file value    (security) Path to the file that defines the pod security admission configuration
    --audit-policy-file value                     (security) Path to the file that defines the audit policy configuration [$RKE2_AUDIT_POLICY_FILE]
    --control-plane-resource-requests value       (components) Control Plane resource requests [$RKE2_CONTROL_PLANE_RESOURCE_REQUESTS]
    --control-plane-resource-limits value         (components) Control Plane resource limits [$RKE2_CONTROL_PLANE_RESOURCE_LIMITS]


### PR DESCRIPTION
A parameter is specified to point to a custome admision config file : https://docs.rke2.io/security/pod_security_standards#pod-security-standards

pod-security-admission-config-file shoud be added to the server documentation