### PR TITLE
Update `Nginx Ingress` entry to be more accurately `Ingress-Nginx`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ RKE2 brings together a number of Open Source technologies to make this all work:
 - [containerd][io-containerd]/[cri][gh-cri-api]
 - [CNI][gh-cni]: Canal ([Calico][org-projectcalico] &amp; [Flannel][gh-flannel]), [Cilium][io-cilium] or [Calico][org-projectcalico]
 - [CoreDNS][io-coredns]
-- [Ingress-Nginx Controller][io-ingress-nginx]
+- [Ingress NGINX Controller][io-ingress-nginx]
 - [Metrics Server][gh-metrics-server]
 - [Helm][sh-helm]
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ RKE2 brings together a number of Open Source technologies to make this all work:
 - [containerd][io-containerd]/[cri][gh-cri-api]
 - [CNI][gh-cni]: Canal ([Calico][org-projectcalico] &amp; [Flannel][gh-flannel]), [Cilium][io-cilium] or [Calico][org-projectcalico]
 - [CoreDNS][io-coredns]
-- [NGINX Ingress Controller][io-ingress-nginx]
+- [Ingress-Nginx Controller][io-ingress-nginx]
 - [Metrics Server][gh-metrics-server]
 - [Helm][sh-helm]
 


### PR DESCRIPTION
## What

- [x] updates the `Nginx Ingress Controller` entry to be `Ingress-Nginx`

## Why

I figured this was more accurate given the current copy on the surface refers to a different ingress controller, and an easy thing to fix!
