### PR TITLE
updated docs to reflect support amazon linux 2023

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -27,10 +27,11 @@ RKE2 has been tested and validated on the following operating systems, and their
 
 | Distro | Version |
 | - | - |
-| Ubuntu | 18.04, 20.04, 22.04 | 
+| Ubuntu | 18.04, 20.04, 22.04 |
 | CentOS/RHEL | 7.8 |
-| Rocky/RHEL | 8.5, 9.1 | 
+| Rocky/RHEL | 8.5, 9.1 |
 | Oracle Linux | 8.7 |
+| Amazon Linux | 2023 |
 | SLES | 15 SP3, SP4 |
 | OpenSUSE, SLE Micro | 5.1, 5.2, 5.3, 5.4 |
 
@@ -71,9 +72,9 @@ Hardware requirements scale based on the size of your deployments. Minimum recom
 *    CPU: 2 Minimum (we recommend at least 4CPU)
 
 ### VM Sizing Guide
-When limited on CPU and RAM on the control-plane + etcd nodes, there could be limitations for the amount of agent nodes that can be joined under standard workload conditions. 
+When limited on CPU and RAM on the control-plane + etcd nodes, there could be limitations for the amount of agent nodes that can be joined under standard workload conditions.
 
-| Server CPU | Server RAM | Number of Agents | 
+| Server CPU | Server RAM | Number of Agents |
 | ---------- | ---------- | ---------------- |
 | 2          | 4 GB       | 0-225            |
 | 4          | 8 GB       | 226-450          |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
@@ -31,6 +31,7 @@ RKE2 已在以下操作系统及其后续非主要版本上进行了测试和验
 | CentOS/RHEL | 7.8 |
 | Rocky/RHEL | 8.5, 9.1 |
 | Oracle Linux | 8.7 |
+| Amazon Linux | 2023 |
 | SLES | 15 SP3, SP4 |
 | OpenSUSE, SLE Micro | 5.1, 5.2, 5.3, 5.4 |
 


### PR DESCRIPTION
Updated `rke2-docs` to reflect support for Amazon Linux 2023 in RKE2 PR -> https://github.com/rancher/rke2/pull/4973

* Related RKE2 Issue: https://github.com/rancher/rke2/issues/4527
* Related AL2023 Issue: https://github.com/amazonlinux/amazon-linux-2023/issues/409