### PR TITLE
Sort "Inbound Network Rules" by port number

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -112,7 +112,7 @@ If you wish to utilize the metrics server, you will need to open port 10250 on e
 
 | Protocol | Port        | Source            | Destination       | Description
 |----------|-------------|-------------------|-------------------|---|
-| ICMP     | 8/0         | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
+| ICMP     | n/a         | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
 | TCP      | 179         | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with BGP
 | TCP      | 2379        | RKE2 server nodes | RKE2 server nodes | etcd client port
 | TCP      | 2380        | RKE2 server nodes | RKE2 server nodes | etcd peer port

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -112,25 +112,25 @@ If you wish to utilize the metrics server, you will need to open port 10250 on e
 
 | Protocol | Port        | Source            | Destination       | Description
 |----------|-------------|-------------------|-------------------|---|
-| TCP      | 9345        | RKE2 agent nodes  | RKE2 server nodes | RKE2 supervisor API
-| TCP      | 6443        | RKE2 agent nodes  | RKE2 server nodes | Kubernetes API
-| UDP      | 8472        | All RKE2 nodes    | All RKE2 nodes    | Required only for Flannel VXLAN
-| TCP      | 10250       | All RKE2 nodes    | All RKE2 nodes    | kubelet metrics
+| ICMP     | 8/0         | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
+| TCP      | 179         | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with BGP
 | TCP      | 2379        | RKE2 server nodes | RKE2 server nodes | etcd client port
 | TCP      | 2380        | RKE2 server nodes | RKE2 server nodes | etcd peer port
 | TCP      | 2381        | RKE2 server nodes | RKE2 server nodes | etcd metrics port
-| TCP      | 30000-32767 | All RKE2 nodes    | All RKE2 nodes    | NodePort port range
-| UDP      | 8472        | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI VXLAN
 | TCP      | 4240        | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
-| ICMP     | 8/0         | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
-| TCP      | 179         | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with BGP
 | UDP      | 4789        | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with VXLAN
 | TCP      | 5473        | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with Typha
+| TCP      | 5473        | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with Typha
+| TCP      | 6443        | RKE2 agent nodes  | RKE2 server nodes | Kubernetes API
+| UDP      | 8472        | All RKE2 nodes    | All RKE2 nodes    | Canal CNI with VXLAN
+| UDP      | 8472        | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI VXLAN
+| UDP      | 8472        | All RKE2 nodes    | All RKE2 nodes    | Required only for Flannel VXLAN
 | TCP      | 9098        | All RKE2 nodes    | All RKE2 nodes    | Calico Typha health checks
 | TCP      | 9099        | All RKE2 nodes    | All RKE2 nodes    | Calico health checks
-| TCP      | 5473        | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with Typha
-| UDP      | 8472        | All RKE2 nodes    | All RKE2 nodes    | Canal CNI with VXLAN
 | TCP      | 9099        | All RKE2 nodes    | All RKE2 nodes    | Canal CNI health checks
+| TCP      | 9345        | RKE2 agent nodes  | RKE2 server nodes | RKE2 supervisor API
+| TCP      | 10250       | All RKE2 nodes    | All RKE2 nodes    | kubelet metrics
+| TCP      | 30000-32767 | All RKE2 nodes    | All RKE2 nodes    | NodePort port range
 | UDP      | 51820       | All RKE2 nodes    | All RKE2 nodes    | Canal CNI with WireGuard IPv4
 | UDP      | 51821       | All RKE2 nodes    | All RKE2 nodes    | Canal CNI with WireGuard IPv6/dual-stack
 
@@ -138,7 +138,7 @@ If you wish to utilize the metrics server, you will need to open port 10250 on e
 
 | Protocol | Port | Source            | Destination       | Description
 |----------|------|-------------------|-------------------|---|
-| UDP      | 4789 | All RKE2 nodes    | All RKE2 nodes    | Required for Calico and Flannel VXLAN
 | TCP      | 179  | All RKE2 nodes    | All RKE2 nodes    | Calico CNI with BGP
+| UDP      | 4789 | All RKE2 nodes    | All RKE2 nodes    | Required for Calico and Flannel VXLAN
 
 Typically, all outbound traffic will be allowed.


### PR DESCRIPTION
This change sort the "Inbound Network Rules" lists by port number in ascending order, making it easier to read and understand. This change also replaces `8/0` with `n/a` as "port" for ICMP, since ICMP does not have port numbers.