### PR TITLE
Fix Airgap Dummy IP + Use newer RKE2 versions in examples

### DIFF
--- a/docs/install/airgap.md
+++ b/docs/install/airgap.md
@@ -32,8 +32,8 @@ If your nodes do not have an interface with a default route, a default route mus
   ```
   ip link add dummy0 type dummy
   ip link set dummy0 up
-  ip addr add 169.254.255.254/31 dev dummy0
-  ip route add default via 169.254.255.255 dev dummy0 metric 1000
+  ip addr add 203.0.113.254/31 dev dummy0
+  ip route add default via 203.0.113.255 dev dummy0 metric 1000
   ```
 
 ## Tarball Method
@@ -81,9 +81,9 @@ system-default-registry: "registry.example.com:5000"
 1. Download the install script, rke2, rke2-images, and sha256sum archives from the release into a directory, as in the example below:
 ```bash
 mkdir /root/rke2-artifacts && cd /root/rke2-artifacts/
-curl -OLs https://github.com/rancher/rke2/releases/download/v1.21.5%2Brke2r2/rke2-images.linux-amd64.tar.zst
-curl -OLs https://github.com/rancher/rke2/releases/download/v1.21.5%2Brke2r2/rke2.linux-amd64.tar.gz
-curl -OLs https://github.com/rancher/rke2/releases/download/v1.21.5%2Brke2r2/sha256sum-amd64.txt
+curl -OLs https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-images.linux-amd64.tar.zst
+curl -OLs https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2.linux-amd64.tar.gz
+curl -OLs https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/sha256sum-amd64.txt
 curl -sfL https://get.rke2.io --output install.sh
 ```
 2. Next, run install.sh using the directory, as in the example below:

--- a/docs/install/methods.md
+++ b/docs/install/methods.md
@@ -63,7 +63,8 @@ The RPMs provide `systemd` units for managing `rke2`, but will need to be config
 In order to use the RPM repository, on a CentOS 7 or RHEL 7 system, run the following bash snippet:
 
 ```bash
-cat << EOF > /etc/yum.repos.d/rancher-rke2-1-18-latest.repo
+export RKE2_MINOR=26
+cat << EOF > /etc/yum.repos.d/rancher-rke2-1-${RKE2_MINOR}-latest.repo
 [rancher-rke2-common-latest]
 name=Rancher RKE2 Common Latest
 baseurl=https://rpm.rancher.io/rke2/latest/common/centos/7/noarch
@@ -71,9 +72,9 @@ enabled=1
 gpgcheck=1
 gpgkey=https://rpm.rancher.io/public.key
 
-[rancher-rke2-1-18-latest]
-name=Rancher RKE2 1.18 Latest
-baseurl=https://rpm.rancher.io/rke2/latest/1.18/centos/7/x86_64
+[rancher-rke2-1-${RKE2_MINOR}-latest]
+name=Rancher RKE2 1.${RKE2_MINOR} Latest
+baseurl=https://rpm.rancher.io/rke2/latest/1.${RKE2_MINOR}/centos/7/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=https://rpm.rancher.io/public.key
@@ -85,7 +86,8 @@ EOF
 In order to use the RPM repository, on a CentOS 8 or RHEL 8 system, run the following bash snippet:
 
 ```bash
-cat << EOF > /etc/yum.repos.d/rancher-rke2-1-18-latest.repo
+export RKE2_MINOR=26
+cat << EOF > /etc/yum.repos.d/rancher-rke2-1-${RKE2_MINOR}-latest.repo
 [rancher-rke2-common-latest]
 name=Rancher RKE2 Common Latest
 baseurl=https://rpm.rancher.io/rke2/latest/common/centos/8/noarch
@@ -93,9 +95,9 @@ enabled=1
 gpgcheck=1
 gpgkey=https://rpm.rancher.io/public.key
 
-[rancher-rke2-1-18-latest]
-name=Rancher RKE2 1.18 Latest
-baseurl=https://rpm.rancher.io/rke2/latest/1.18/centos/8/x86_64
+[rancher-rke2-1-${RKE2_MINOR}-latest]
+name=Rancher RKE2 1.${RKE2_MINOR} Latest
+baseurl=https://rpm.rancher.io/rke2/latest/1.${RKE2_MINOR}/centos/8/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=https://rpm.rancher.io/public.key

--- a/docs/install/windows_airgap.md
+++ b/docs/install/windows_airgap.md
@@ -39,7 +39,7 @@ This will require a reboot for the `Containers` feature to properly function.
 
     ``` powershell
     $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.21.4%2Brke2r2/rke2-windows-1809-amd64-images.tar.gz -OutFile /var/lib/rancher/rke2/agent/images/rke2-windows-1809-amd64-images.tar.gz 
+    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-windows-1809-amd64-images.tar.gz -OutFile /var/lib/rancher/rke2/agent/images/rke2-windows-1809-amd64-images.tar.gz 
     ```
 
 
@@ -47,14 +47,14 @@ This will require a reboot for the `Containers` feature to properly function.
 
     ``` powershell
     $ProgressPreference = 'SilentlyContinue'  
-    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.21.4%2Brke2r2/rke2-windows-2004-amd64-images.tar.gz -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-2004-amd64-images.tar.gz
+    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-windows-2004-amd64-images.tar.gz -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-2004-amd64-images.tar.gz
     ```
 
     - **Windows Server SAC 20H2 (amd64) (OS Build 19042.1110)**
 
     ``` powershell
     $ProgressPreference = 'SilentlyContinue'  
-    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.21.4%2Brke2r2/rke2-windows-20H2-amd64-images.tar.gz -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-20H2-amd64-images.tar.gz 
+    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-windows-20H2-amd64-images.tar.gz -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-20H2-amd64-images.tar.gz 
     ```
 
     #### Using tar.zst image tarballs
@@ -63,7 +63,7 @@ This will require a reboot for the `Containers` feature to properly function.
 
     ``` powershell
     $ProgressPreference = 'SilentlyContinue'  
-    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.21.4%2Brke2r2/rke2-windows-1809-amd64-images.tar.zst -OutFile /var/lib/rancher/rke2/agent/images/rke2-windows-1809-amd64-images.tar.zst 
+    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-windows-1809-amd64-images.tar.zst -OutFile /var/lib/rancher/rke2/agent/images/rke2-windows-1809-amd64-images.tar.zst 
     ```
 
 
@@ -71,14 +71,14 @@ This will require a reboot for the `Containers` feature to properly function.
 
     ``` powershell
     $ProgressPreference = 'SilentlyContinue'  
-    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.21.4%2Brke2r2/rke2-windows-2004-amd64-images.tar.zst -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-2004-amd64-images.tar.zst 
+    Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-windows-2004-amd64-images.tar.zst -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-2004-amd64-images.tar.zst 
     ```
 
     - **Windows Server SAC 20H2 (amd64) (OS Build 19042.1110)**
 
     ``` powershell
     $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest hhttps://github.com/rancher/rke2/releases/download/v1.21.4%2Brke2r2/rke2-windows-20H2-amd64-images.tar.zst -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-20H2-amd64-images.tar.zst
+    Invoke-WebRequest hhttps://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-windows-20H2-amd64-images.tar.zst -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-20H2-amd64-images.tar.zst
     ```
 
     - Use `rke2-windows-<BUILD_VERSION>-amd64.tar.gz` or `rke2-windows-<BUILD_VERSION>-amd64.tar.zst`. Zstandard offers better compression ratios and faster decompression speeds compared to pigz.
@@ -109,7 +109,7 @@ These steps should only be performed after completing one of either the [Tarball
 
 1. Obtain the Windows RKE2 binary file `rke2-windows-amd64.exe`. Ensure the binary is named `rke2.exe` and place it in `c:/usr/local/bin`. 
 ```powershell
-Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.21.4%2Brke2r2/rke2-windows-amd64.exe -OutFile c:/usr/local/bin/rke2.exe
+Invoke-WebRequest https://github.com/rancher/rke2/releases/download/v1.26.10%2Brke2r2/rke2-windows-amd64.exe -OutFile c:/usr/local/bin/rke2.exe
 ```
 
 2. Configure the rke2-agent for Windows


### PR DESCRIPTION
- Now IP used is one designated as a IPv4 testing/docs range.
- RPM repo snippets are more generic with clear support for any RKE2 minor
Signed-off-by: Derek Nola <derek.nola@suse.com>