### PR TITLE
Admonition Migration

### DIFF
--- a/docs/install/airgap.md
+++ b/docs/install/airgap.md
@@ -6,7 +6,7 @@ RKE2 can be installed in an air-gapped environment with two different methods. Y
 
 ## Prerequisites
 
-:::warning Important
+:::warning
 If your node has NetworkManager installed and enabled, [ensure that it is configured to ignore CNI-managed interfaces.](../known_issues.md#networkmanager)
 :::
 

--- a/docs/install/network_options.md
+++ b/docs/install/network_options.md
@@ -58,7 +58,7 @@ For more information about the full options of the Canal config please refer to 
 Canal requires the iptables or xtables-nft package to be installed on the node.
 :::
 
-:::caution
+:::warning
 Canal is currently not supported on clusters with Windows nodes.
 :::
 
@@ -106,7 +106,7 @@ spec:
 
 For more information, please check the [upstream docs](https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/)
 
-:::caution
+:::warning
 Cilium is currently not supported in the Windows installation of RKE2
 :::
 

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -35,7 +35,7 @@ RKE2 has been tested and validated on the following operating systems, and their
 | OpenSUSE, SLE Micro | 5.1, 5.2, 5.3, 5.4 |
 
 ### Windows
-:::caution Version Gate
+:::warning Version Gate
 Experimental as of [v1.21.3+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.21.3%2Brke2r1)
 :::
 

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -2,7 +2,7 @@
 title: Uninstall
 ---
 
-:::caution
+:::warning
 Uninstalling RKE2 deletes the cluster data and all of the scripts.
 :::
 

--- a/docs/release-notes/v1.24.X.md
+++ b/docs/release-notes/v1.24.X.md
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # v1.24.X
 
-:::caution Upgrade Notice
+:::warning Upgrade Notice
 Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes).
 :::
 

--- a/docs/release-notes/v1.25.X.md
+++ b/docs/release-notes/v1.25.X.md
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # v1.25.X
 
-:::caution Upgrade Notice
+:::warning Upgrade Notice
 Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#urgent-upgrade-notes).
 :::
 

--- a/docs/release-notes/v1.26.X.md
+++ b/docs/release-notes/v1.26.X.md
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # v1.26.X
 
-:::caution Upgrade Notice
+:::warning Upgrade Notice
 Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#urgent-upgrade-notes).
 :::
 

--- a/docs/release-notes/v1.27.X.md
+++ b/docs/release-notes/v1.27.X.md
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # v1.27.X
 
-:::caution Upgrade Notice
+:::warning Upgrade Notice
 Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#urgent-upgrade-notes).
 :::
 

--- a/docs/release-notes/v1.28.X.md
+++ b/docs/release-notes/v1.28.X.md
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # v1.28.X
 
-:::caution Upgrade Notice
+:::warning Upgrade Notice
 Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#urgent-upgrade-notes).
 :::
 

--- a/docs/security/certificates.md
+++ b/docs/security/certificates.md
@@ -107,7 +107,7 @@ graph TD
 
 #### Using the Example Script
 
-:::important
+:::info Important
 If you want to sign the cluster CA certificates with an existing root CA using the example script, you must place the root and intermediate files in the target directory prior to running the script.
 If the files do not exist, the script will create new root and intermediate CA certificates.
 :::

--- a/docs/security/certificates.md
+++ b/docs/security/certificates.md
@@ -143,7 +143,7 @@ If the script generated root and/or intermediate CA files, you should back up th
 To rotate custom CA certificates, use the `rke2 certificate rotate-ca` subcommand.
 Updated files must be staged into a temporary directory, loaded into the datastore, and rke2 must be restarted on all nodes to use the updated certificates.
 
-:::caution
+:::warning
 You must not overwrite the currently in-use data in `/var/lib/rancher/rke2/server/tls`.  
 Stage the updated certificates and keys into a separate directory.
 :::
@@ -186,7 +186,7 @@ The token may be stored in a `.env` file, systemd unit, or config.yaml, dependin
 To rotate the RKE2-generated self-signed CA certificates, use the `rke2 certificate rotate-ca` subcommand.
 Updated files must be staged into a temporary directory, loaded into the datastore, and rke2 must be restarted on all nodes to use the updated certificates.
 
-:::caution
+:::warning
 You must not overwrite the currently in-use data in `/var/lib/rancher/rke2/server/tls`.  
 Stage the updated certificates and keys into a separate directory.
 :::
@@ -295,7 +295,7 @@ The service-account issuer key is an RSA private key used to sign service-accoun
 When rotating the service-account issuer key, at least one old key should be retained in the file so that existing service-account tokens are not invalidated.
 It can be rotated independent of the cluster CAs by using the `rke2 certificate rotate-ca` to install only an updated `service.key` file that includes both the new and old keys.
 
-:::caution
+:::warning
 You must not overwrite the currently in-use data in `/var/lib/rancher/rke2/server/tls`.  
 Stage the updated key into a separate directory.
 :::

--- a/docs/security/hardening_guide.md
+++ b/docs/security/hardening_guide.md
@@ -179,7 +179,7 @@ When ran with a valid "cis-1.XX" profile, RKE2 will put `NetworkPolicies` in pla
 
 The `NetworkPolicy` used will only allow pods within the same namespace to talk to each other. The notable exception to this is that it allows DNS requests to be resolved.
 
-:::caution Operator Intervention Required
+:::warning Operator Intervention Required
 Operators must manage network policies as normal for additional namespaces that are created.
 :::
 
@@ -195,7 +195,7 @@ For each namespace including `default` and `kube-system` on a standard RKE2 inst
 automountServiceAccountToken: false
 ```
 
-:::caution Operator Intervention Required
+:::warning Operator Intervention Required
 
 For namespaces created by the cluster operator, the following script and configuration file can be used to configure the `default` service account.
 
@@ -241,7 +241,7 @@ rules:
 - level: None
 ```
 
-:::caution Operator Intervention Required
+:::warning Operator Intervention Required
 To start logging requests to the API Server, at least `level` parameter must be modified, for example, to `Metadata`. Detailed information about policy configuration for the API server can be found in the Kubernetes [documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/).
 
 After adapting the audit policy, RKE2 must be restarted to load the new configuration.

--- a/docs/security/pod_security_policies.md
+++ b/docs/security/pod_security_policies.md
@@ -4,7 +4,7 @@ title: Default Pod Security Policies
 
 This document describes how RKE2 configures `PodSecurityPolicies` and `NetworkPolicies` in order to be secure-by-default while also providing operators with maximum configuration flexibility.
 
-:::caution Version Gate
+:::info Version Gate
 This document applies to RKE2 v1.24 and older, please refer to the [Pod Security Standards Documentation](./pod_security_standards.md) for the default policy information for RKE2 v1.25 and higher.
 :::
 

--- a/docs/security/pod_security_standards.md
+++ b/docs/security/pod_security_standards.md
@@ -4,7 +4,7 @@ title: Default Pod Security Standards
 
 This document describes how RKE2 configures `PodSecurityStandards` and `NetworkPolicies` in order to be secure-by-default while also providing operators with maximum configuration flexibility.
 
-:::caution Version Gate
+:::info Version Gate
 This document applies to RKE2 v1.25 and newer, please refer to the [Pod Security Policies Documentation](./pod_security_policies.md) for the default policy information for RKE2 v1.24 and older.
 :::
 

--- a/docs/security/secrets_encryption.md
+++ b/docs/security/secrets_encryption.md
@@ -44,7 +44,7 @@ Once enabled any created secret will be encrypted with this key. Note that if yo
 
 ## Secrets Encryption Tool
 
-:::caution Version Gate
+:::info Version Gate
 Available as of [v1.21.8+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.21.8%2Brke2r1)
 :::
 

--- a/docs/security/secrets_encryption.md
+++ b/docs/security/secrets_encryption.md
@@ -54,7 +54,7 @@ RKE2 contains a subcommand `secrets-encrypt`, which allows administrators to per
 - Rotating and deleting encryption keys
 - Reencrypting secrets
 
-:::warning
+:::danger
 Failure to follow proper procedure when rotating secrets encryption keys can cause permanent data loss. [Creating a snapshot](../backup_restore.md) before rotating is recommended. Proceed with caution.
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/network_options.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/network_options.md
@@ -57,7 +57,7 @@ spec:
 Canal 要求在节点上安装 iptables 或 xtables-nft 包。
 :::
 
-:::caution
+:::warning
 具有 Windows 节点的集群目前不支持 Canal。
 :::
 
@@ -105,7 +105,7 @@ spec:
 
 有关更多信息，请查看[上游文档](https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/)。
 
-:::caution
+:::warning
 RKE2 的 Windows 安装目前不支持 Cilium。
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
@@ -35,7 +35,7 @@ RKE2 已在以下操作系统及其后续非主要版本上进行了测试和验
 | OpenSUSE, SLE Micro | 5.1, 5.2, 5.3, 5.4 |
 
 ### Windows
-:::caution 版本
+:::warning 版本
 从 [v1.21.3+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.21.3%2Brke2r1) 开始作为实验性功能。
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/uninstall.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/uninstall.md
@@ -2,7 +2,7 @@
 title: 卸载
 ---
 
-:::caution
+:::warning
 卸载 RKE2 会删除集群数据和所有脚本。
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening_guide.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/hardening_guide.md
@@ -179,7 +179,7 @@ When ran with a valid "cis-1.XX" profile, RKE2 will put `NetworkPolicies` in pla
 
 The `NetworkPolicy` used will only allow pods within the same namespace to talk to each other. The notable exception to this is that it allows DNS requests to be resolved.
 
-:::caution Operator Intervention Required
+:::warning Operator Intervention Required
 Operators must manage network policies as normal for additional namespaces that are created.
 :::
 
@@ -195,7 +195,7 @@ For each namespace including `default` and `kube-system` on a standard RKE2 inst
 automountServiceAccountToken: false
 ```
 
-:::caution Operator Intervention Required
+:::warning Operator Intervention Required
 
 For namespaces created by the cluster operator, the following script and configuration file can be used to configure the `default` service account.
 
@@ -241,7 +241,7 @@ rules:
 - level: None
 ```
 
-:::caution Operator Intervention Required
+:::warning Operator Intervention Required
 To start logging requests to the API Server, at least `level` parameter must be modified, for example, to `Metadata`. Detailed information about policy configuration for the API server can be found in the Kubernetes [documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/).
 
 After adapting the audit policy, RKE2 must be restarted to load the new configuration.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/pod_security_policies.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/pod_security_policies.md
@@ -4,7 +4,7 @@ title: 默认 Pod 安全策略
 
 本文档描述了 RKE2 如何配置 `PodSecurityPolicies` 和 `NetworkPolicies` 来确保默认安全，同时还为操作人员提供了最大的配置灵活性。
 
-:::caution 版本
+:::info 版本
 本文档适用于 RKE2 v1.24 及更早版本，请参阅 [Pod 安全标准文档](./pod_security_standards.md)了解 RKE2 v1.25 及更高版本的默认策略。
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/pod_security_standards.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/pod_security_standards.md
@@ -4,7 +4,7 @@ title: 默认 Pod 安全标准
 
 本文档描述了 RKE2 如何配置 `PodSecurityStandards` 和 `NetworkPolicies` 来确保默认安全，同时还为操作人员提供了最大的配置灵活性。
 
-:::caution 版本
+:::info 版本
 本文档适用于 RKE2 v1.25 及更新版本，请参阅 [Pod 安全策略文档](./pod_security_policies.md)了解 RKE2 v1.24 及更低版本的默认策略。
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/secrets_encryption.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/secrets_encryption.md
@@ -44,7 +44,7 @@ RKE2 支持[静态加密 Secret](https://kubernetes.io/docs/tasks/administer-clu
 
 ## Secret 加密工具
 
-:::caution 版本
+:::info 版本
 从 [v1.21.8+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.21.8%2Brke2r1) 起可用
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/security/secrets_encryption.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/security/secrets_encryption.md
@@ -54,7 +54,7 @@ RKE2 包含一个实用的子命令 `secrets-encrypt`，它允许管理员执行
 - 轮换和删除加密密钥
 - 重新加密 Secret
 
-:::warning
+:::danger
 如果你在轮换 Secret 加密密钥时没有遵循正确的程序，数据可能永久丢失。建议在轮换之前[创建快照](../backup_restore.md)。因此，请谨慎操作。
 :::
 

--- a/scripts/collect-all-release-notes.sh
+++ b/scripts/collect-all-release-notes.sh
@@ -23,7 +23,7 @@ for minor in $MINORS; do
             title="---\nhide_table_of_contents: true\n---\n\n# ${minor}.X\n"
             echo -e "${title}" >> $global_table
             upgrade_link="[Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-${minor:1}.md#urgent-upgrade-notes)"
-            upgrade_warning=":::caution Upgrade Notice\nBefore upgrading from earlier releases, be sure to read the Kubernetes ${upgrade_link}.\n:::\n"
+            upgrade_warning=":::warning Upgrade Notice\nBefore upgrading from earlier releases, be sure to read the Kubernetes ${upgrade_link}.\n:::\n"
             echo -e "${upgrade_warning}" >> $global_table
             echo -n "| Version | Release date " >> $global_table
             # RKE2 Core Components


### PR DESCRIPTION
With Docusaurous v3/v4 legacy admonition are being removed

## Changes
The following admonitions have been migrated
- Red/Fire goes from `:::warning` to `:::danger`
- Yellow goes from `:::caution` to `:::warning`
- Blue goes from `:::important` to `:::info`

Signed-off-by: Derek Nola <derek.nola@suse.com>