### PR TITLE
Modify release notes to include link to GH release page

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -2,6 +2,8 @@ name: Collect Release Notes
 on:
   workflow_dispatch
 
+env:
+  MINORS: "v1.25 v1.26 v1.27 v1.28"
 permissions:
   contents: write
   pull-requests: write
@@ -11,10 +13,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Generate release notes
+      - name: Remove old release notes
         run: |
-          rm docs/release-notes/*.md
-          scripts/collect-all-release-notes.sh
+          for minor in $MINORS; do
+            rm docs/release-notes/$minor*.md
+          done 
+      - name: Generate release notes
+        run: scripts/collect-all-release-notes.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Pull Request

--- a/docs/release-notes/v1.24.X.md
+++ b/docs/release-notes/v1.24.X.md
@@ -68,7 +68,7 @@ This release updates Kubernetes to v1.24.17, and fixes a number of issues.
 * Add additional static pod cleanup during cluster reset [(#4727)](https://github.com/rancher/rke2/pull/4727)
 
 -----
-## Release v1.24.16+rke2r1
+## Release [v1.24.16+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.16+rke2r1)
 <!-- v1.24.16+rke2r1 -->
 
 This release updates Kubernetes to v1.24.16, and fixes a number of issues.
@@ -94,7 +94,7 @@ cat /var/lib/rancher/rke2/server/token
 * Update to v1.24.16 [(#4497)](https://github.com/rancher/rke2/pull/4497)
 
 -----
-## Release v1.24.15+rke2r1
+## Release [v1.24.15+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.15+rke2r1)
 <!-- v1.24.15+rke2r1 -->
 
 This release updates Kubernetes to v1.24.15, and fixes a number of issues.
@@ -118,7 +118,7 @@ cat /var/lib/rancher/rke2/server/token
 * Use our own file copy logic instead of continuity [(#4391)](https://github.com/rancher/rke2/pull/4391)
 
 -----
-## Release v1.24.14+rke2r1
+## Release [v1.24.14+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.14+rke2r1)
 <!-- v1.24.14+rke2r1 -->
 
 This release updates Kubernetes to v1.24.14, and fixes a number of issues.
@@ -152,7 +152,7 @@ cat /var/lib/rancher/rke2/server/token
 * Bump vsphere csi to remove duplicate CSI deployment. [(#4298)](https://github.com/rancher/rke2/pull/4298)
 
 -----
-## Release v1.24.13+rke2r1
+## Release [v1.24.13+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.13+rke2r1)
 <!-- v1.24.13+rke2r1 -->
 
 This release updates Kubernetes to v1.24.13, and fixes a number of issues.
@@ -176,7 +176,7 @@ cat /var/lib/rancher/rke2/server/token
 * Update Kubernetes to v1.24.13 [(#4117)](https://github.com/rancher/rke2/pull/4117)
 
 -----
-## Release v1.24.12+rke2r1
+## Release [v1.24.12+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.12+rke2r1)
 <!-- v1.24.12+rke2r1 -->
 
 This release updates Kubernetes to v1.24.12, and fixes a number of issues.
@@ -203,7 +203,7 @@ cat /var/lib/rancher/rke2/server/token
 * Update 1.24 and Go [(#4030)](https://github.com/rancher/rke2/pull/4030)
 
 -----
-## Release v1.24.11+rke2r1
+## Release [v1.24.11+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.11+rke2r1)
 <!-- v1.24.11+rke2r1 -->
 
 This release updates Kubernetes to v1.24.11, and fixes a number of issues.
@@ -236,7 +236,7 @@ cat /var/lib/rancher/rke2/server/token
 * Update to kubernetes v1.24.11 [(#3950)](https://github.com/rancher/rke2/pull/3950)
 
 -----
-## Release v1.24.10+rke2r1
+## Release [v1.24.10+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.10+rke2r1)
 <!-- v1.24.10+rke2r1 -->
 
 This release updates Kubernetes to v1.24.10 to backport registry changes and fix two critical issues.
@@ -260,7 +260,7 @@ cat /var/lib/rancher/rke2/server/token
 * Bump K3s version for tls-cipher-suites fix [(#3798)](https://github.com/rancher/rke2/pull/3798)
 
 -----
-## Release v1.24.9+rke2r2
+## Release [v1.24.9+rke2r2](https://github.com/rancher/rke2/releases/tag/v1.24.9+rke2r2)
 <!-- v1.24.9+rke2r2 -->
 
 This release updates containerd to v1.6.14 to resolve an issue where pods would lose their CNI information when containerd was restarted.
@@ -281,7 +281,7 @@ cat /var/lib/rancher/rke2/server/token
   * Windows agents now use the k3s fork of containerd, which includes support for registry rewrites.
 
 -----
-## Release v1.24.9+rke2r1
+## Release [v1.24.9+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.9+rke2r1)
 <!-- v1.24.9+rke2r1 -->
 
 > ## ⚠️ WARNING
@@ -314,7 +314,7 @@ cat /var/lib/rancher/rke2/server/token
 * Bump ingress-nginx [(#3705)](https://github.com/rancher/rke2/pull/3705)
 
 -----
-## Release v1.24.8+rke2r1
+## Release [v1.24.8+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.8+rke2r1)
 <!-- v1.24.8+rke2r1 -->
 
 This release updates Kubernetes to v1.24.8, fixes a number of minor issues, and includes security updates.
@@ -339,7 +339,7 @@ cat /var/lib/rancher/rke2/server/token
 * Use the Cilium chart that fixes the portmap issue with system_default… [(#3554)](https://github.com/rancher/rke2/pull/3554)
 
 -----
-## Release v1.24.7+rke2r1
+## Release [v1.24.7+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.7+rke2r1)
 <!-- v1.24.7+rke2r1 -->
 
 This release updates Kubernetes to v1.24.7, fixes a number of minor issues, and includes security updates.
@@ -363,7 +363,7 @@ cat /var/lib/rancher/rke2/server/token
 * Bump CCM image tag  [(#3466)](https://github.com/rancher/rke2/pull/3466)
 
 -----
-## Release v1.24.6+rke2r1
+## Release [v1.24.6+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.6+rke2r1)
 <!-- v1.24.6+rke2r1 -->
 
 This release updates Kubernetes to v1.24.6, fixes a number of minor issues, and includes security updates.
@@ -394,7 +394,7 @@ cat /var/lib/rancher/rke2/server/token
 * Update k8s to 1.24.6 [(#3370)](https://github.com/rancher/rke2/pull/3370)
 
 -----
-## Release v1.24.4+rke2r1
+## Release [v1.24.4+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.4+rke2r1)
 <!-- v1.24.4+rke2r1 -->
 
 This release updates Kubernetes to v1.24.4, fixes a number of minor issues, and includes security updates.
@@ -431,7 +431,7 @@ cat /var/lib/rancher/rke2/server/token
 * Bump K3s version for v1.24 [(#3265)](https://github.com/rancher/rke2/pull/3265)
 
 -----
-## Release v1.24.3+rke2r1
+## Release [v1.24.3+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.3+rke2r1)
 <!-- v1.24.3+rke2r1 -->
 
 This release updates Kubernetes to v1.24.3, fixes a number of minor issues, and includes security updates.
@@ -457,7 +457,7 @@ cat /var/lib/rancher/rke2/server/token
 * Consolidate staticPod timeout to static 30 minutes [(#3166)](https://github.com/rancher/rke2/pull/3166)
 
 -----
-## Release v1.24.2+rke2r1
+## Release [v1.24.2+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.24.2+rke2r1)
 <!-- v1.24.2+rke2r1 -->
 
 This release updates Kubernetes to v1.24.2, fixes a number of minor issues, and includes security updates.
@@ -495,7 +495,7 @@ cat /var/lib/rancher/rke2/server/token
 * Bump K3s version for cluster upgrade egress-selector-mode fix [(#3122)](https://github.com/rancher/rke2/pull/3122)
 
 -----
-## Release v1.24.1+rke2r2
+## Release [v1.24.1+rke2r2](https://github.com/rancher/rke2/releases/tag/v1.24.1+rke2r2)
 <!-- v1.24.1+rke2r2 -->
 
 This release is RKE2's first in the v1.24 line. This release updates Kubernetes to v1.24.1.

--- a/scripts/collect-all-release-notes.sh
+++ b/scripts/collect-all-release-notes.sh
@@ -5,7 +5,7 @@ function gen_md_link()
     echo "${release_link}"
 }
 
-MINORS="v1.24 v1.25 v1.26 v1.27 v1.28"
+MINORS=${MINORS:-"v1.25 v1.26 v1.27 v1.28"}
 
 for minor in $MINORS; do
     product=rke2
@@ -41,8 +41,8 @@ for minor in $MINORS; do
         previous=$patch
         # Remove the component table from each individual release notes
         perl -i -p0e 's/^## Packaged Component Versions.*?^-----/-----/gms' "${file}"
-        # Add extra levels for Docusaurus Sidebar
-        sed -i 's/^# Release/## Release/' "${file}"
+        # Add extra levels for Docusaurus Sidebar and link to GH release page
+        sed -i 's/^# Release \(.*\)/## Release [\1](https:\/\/github.com\/rancher\/rke2\/releases\/tag\/\1)/' "${file}"
         sed -i 's/^## Changes since/### Changes since/' "${file}"
     done
     echo -e "\n<br />\n" >> $global_table


### PR DESCRIPTION
## Changes
- Update release notes action to only cleanup currently changing release notes (i.e. don't remove older releases notes like 1.24)
- Modify the release notes script to include a external link to the GH release page of each  patch release
- Update v1.24.X.md with new link above (all other release notes will be updated using the workflow bot)


![image](https://github.com/rancher/rke2-docs/assets/11727736/71982e66-cdeb-4b5a-9fbd-5ca151949d46)


Signed-off-by: Derek Nola <derek.nola@suse.com>