### PR TITLE
Switch to Docusaurous themedImage

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,7 +4,17 @@ sidebar_position: 1
 title: "Introduction"
 ---
 
-![](/img/logo-horizontal-rke2.svg#gh-light-mode-only)![](/img/logo-horizontal-rke2-dark.svg#gh-dark-mode-only)
+import ThemedImage from '@theme/ThemedImage';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+<ThemedImage
+  sources={{
+    light: useBaseUrl('/img/logo-horizontal-rke2.svg'),
+    dark: useBaseUrl('/img/logo-horizontal-rke2-dark.svg'),
+  }}
+  style={{width: "350px"}}
+/>
+
 
 RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution.
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -82,11 +82,6 @@ hr {
   padding: 0 var(--ifm-pre-padding);
 }
 
-[data-theme='light'] img[src$='#gh-dark-mode-only'],
-[data-theme='dark'] img[src$='#gh-light-mode-only'] {
-  display: none;
-}
-
 /* Mobile */
 @media (max-width: 996px) {
 


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

The move to Docsaurous 3.0 seemed to have broken the [GH Themed Images](https://docusaurus.io/docs/markdown-features/assets#github-style-themed-images) support. 

Instead we switch to the internal ThemedImage component.

Addresses: https://github.com/rancher/rke2-docs/issues/133

![image](https://github.com/rancher/rke2-docs/assets/11727736/5dcfd2da-86a7-412d-889b-28ce6e501896)
