### PR TITLE
Hide new rotate-keys command until stable

### DIFF
--- a/docs/security/secrets_encryption.md
+++ b/docs/security/secrets_encryption.md
@@ -58,7 +58,7 @@ RKE2 contains a subcommand `secrets-encrypt`, which allows administrators to per
 Failure to follow proper procedure when rotating secrets encryption keys can cause permanent data loss. [Creating a snapshot](../backup_restore.md) before rotating is recommended. Proceed with caution.
 :::
 
-### New Encryption Key Rotation
+<!-- ### New Encryption Key Rotation
 
 :::warning Expiremental Version Gate
 Available as of [v1.28.1+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.28.1%2Brke2r1). This new version of the tool utilizes K8s [automatic config reloading](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#configure-automatic-reloading) which is currently in beta. GA is expected in v1.29.0
@@ -116,7 +116,7 @@ In this example, 3 servers are used to for a HA cluster, referred to as S1, S2, 
 
 
 </TabItem>
-</Tabs>
+</Tabs> -->
 
 ### Encryption Key Rotation Classic
 


### PR DESCRIPTION
The `secrets-encrypt rotate-keys` command has proven to be to unstable with upstream changing how KMSv2 works. Removing information from docs until the command is GA.
Signed-off-by: Derek Nola <derek.nola@suse.com>