### PR TITLE
docs: fix incorrect file extension

### DIFF
--- a/docs/security/cis_self_assessment123.md
+++ b/docs/security/cis_self_assessment123.md
@@ -194,7 +194,7 @@ Container Network Interface provides various networking options for overlay netw
 
 **Audit:**
 ```bash
-stat -c %a /var/lib/rancher/rke2/server/manifests/rke2-canal.yml
+stat -c %a /var/lib/rancher/rke2/server/manifests/rke2-canal.yaml
 644
 ```
 
@@ -213,7 +213,7 @@ Container Network Interface provides various networking options for overlay netw
 
 **Audit:**
 ```bash
-stat -c %U:%G /var/lib/rancher/rke2/server/manifests/rke2-canal.yml
+stat -c %U:%G /var/lib/rancher/rke2/server/manifests/rke2-canal.yaml
 root:root
 ```
 


### PR DESCRIPTION
This PR will fix incorrect file extensions mentioned in the documentation (tested against v1.26.13+rke2r1).