### PR TITLE
Clarify multiple volume mounts

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -227,8 +227,8 @@ Multiple volume mounts can be specified for the same component by passing the fl
 ```yaml
 # /etc/rancher/rke2/config.yaml
 kube-apiserver-extra-mount: 
-   - "/tmp/foo.yaml:/root/foo.yaml"
-   - "/tmp/bar.txt:/etc/bar.txt:ro"
+   - "/tmp/foo:/root/foo"
+   - "/tmp/bar:/etc/bar:ro"
 ```
 
 ## Extra Control Plane Component Environment Variables


### PR DESCRIPTION
RKE service fails to start when files are mounted. 

It is only possible to mount directories. 

See open issue: https://github.com/rancher/rke2/issues/1793