### PR TITLE
Remove the hyper-v feature as it is not needed in the end

### DIFF
--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -128,12 +128,7 @@ In the new Powershell window, run the following command to install the container
 ```powershell
 Enable-WindowsOptionalFeature -Online -FeatureName containers –All
 ```
-As well as the following command to install all the required HNS networking components:
-```powershell
-Install-WindowsFeature -Name Hyper-V-PowerShell
-```
-
-This will require a reboot for the `Containers` and the `Hyper-V` features to properly function.
+This will require a reboot for the `Containers` feature to properly function.
 
 #### 1. Download the Install Script
 ```powershell


### PR DESCRIPTION
I made a mistake and got confused by something else. The containers feature is enough to get all windows requirements in place