### PR TITLE
Update ha.md to add a note in section "1. Configure the Fixed Registr…

### DIFF
--- a/docs/install/ha.md
+++ b/docs/install/ha.md
@@ -39,7 +39,7 @@ This endpoint can be set up using any number approaches, such as:
 
 This endpoint can also be used for accessing the Kubernetes API. So you can, for example, modify your [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file to point to it instead of a specific node.
 
-Note that the `rke2 server` process listens on port `9345` for new nodes to register. The Kubernetes API is served on port `6443`, as normal. Configure your load balancer accordingly.
+Note that the `rke2 server` process listens on port `9345` for new nodes to register. The Kubernetes API is served on port `6443`, as normal. Configure your load balancer accordingly. Note that when adding new nodes to the cluster, additional checks may be required in your load balancer to determine if the server is ready. For example, an additional monitoring check in the load balancer for port 6443 can help determine if the node can join the cluster.
 
 ### 2. Launch the first server node
 The first server node establishes the secret token that other server or agent nodes will register with when connecting to the cluster.


### PR DESCRIPTION
…ation Address"

Pensionsmyndigheten customer suggested an update in our documentation to prevent race conditions in HA setups when using F5 load balancer. "They encounter random join failures for additional rke2 master nodes, as he described as follows: The problem is that rke2 immediately starts to listen to port 9345 when the rke2-server service is started (even though it has not completed (or even started) the installation process to be a functioning member of the cluster. This fools the load balancer into thinking that the new node is ready for requests on port 9345 while only the first node can actually respond to requests for joining the cluster. We solved this by adding additional port monitoring on port 6443 to determine if the nodes are ready in the load balancer."