### PR TITLE
Update selinux.md to add a note on a possible required reboot for CentOS/RHEL systems

### DIFF
--- a/docs/security/selinux.md
+++ b/docs/security/selinux.md
@@ -7,6 +7,8 @@ The [policy](https://github.com/rancher/rke2-selinux) supporting this is a speci
 [container-selinux](https://github.com/containers/container-selinux) policy for containerd. It accounts
 for the non-standard location(s) which containerd is installed and places persistent and ephemeral state.
 
+Note: A Linux server reboot might be required after installing the rke2-selinux rpm package and before starting the rke2 installation on CentOS/RHEL distributions.
+
 #### Custom Context Labels
 
 RKE2 runs control-plane services as static pods which require access to multiple

--- a/docs/security/selinux.md
+++ b/docs/security/selinux.md
@@ -7,7 +7,7 @@ The [policy](https://github.com/rancher/rke2-selinux) supporting this is a speci
 [container-selinux](https://github.com/containers/container-selinux) policy for containerd. It accounts
 for the non-standard location(s) which containerd is installed and places persistent and ephemeral state.
 
-Note: A Linux server reboot might be required after installing the rke2-selinux rpm package and before starting the rke2 installation on CentOS/RHEL distributions.
+Note: In some circumstances, a reboot of the node may be required after installing the rke2-selinux package and before starting the rke2 service. If you encounter denials in your selinux audit log despite installation of the rke2-selinux and container-selinux packages, please reboot the node.
 
 #### Custom Context Labels
 


### PR DESCRIPTION
After installing the required packages, he noticed that the canal & coredns installation failed at some point: 
```console
# kubectl get nodes
NAME            STATUS     ROLES                       AGE    VERSION
mgxrk8sinf339   NotReady   control-plane,etcd,master   120m   v1.27.10+rke2r1

# kubectl get pods -A
NAMESPACE     NAME                                                  READY   STATUS              RESTARTS      AGE
kube-system   cloud-controller-manager-mgxrk8sinf339                1/1     Running             0             40s
kube-system   etcd-mgxrk8sinf339                                    1/1     Running             0             16s
kube-system   helm-install-rke2-canal-r4rgk                         0/1     RunContainerError   2 (13s ago)   35s
kube-system   helm-install-rke2-coredns-d9c4c                       0/1     RunContainerError   2 (12s ago)   35s
kube-system   helm-install-rke2-ingress-nginx-4ppm2                 0/1     Pending             0             35s
kube-system   helm-install-rke2-metrics-server-nsq55                0/1     Pending             0             35s
kube-system   helm-install-rke2-snapshot-controller-crd-pvgfc       0/1     Pending             0             35s
kube-system   helm-install-rke2-snapshot-controller-p94xh           0/1     Pending             0             35s
kube-system   helm-install-rke2-snapshot-validation-webhook-lbnwz   0/1     Pending             0             35s
kube-system   kube-apiserver-mgxrk8sinf339                          1/1     Running             0             41s
kube-system   kube-controller-manager-mgxrk8sinf339                 1/1     Running             0             39s
kube-system   kube-proxy-mgxrk8sinf339                              1/1     Running             0             35s
kube-system   kube-scheduler-mgxrk8sinf339                          1/1     Running             0             39s
```

With these notable errors:
repeated in /var/lib/rancher/rke2/agent/containerd/containerd.log
`time="2024-03-04T12:32:12.023610851+01:00" level=error msg="StartContainer for \"f8294bc42fb256a129dcbc0fef03a71ea4cf5687bb424c077fb07bc5bcf793a1\" failed" error="failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"entry\": executable file not found in $PATH: unknown"`

Although I could not reproduce this issue in a Laboratory, the customer reported that he solved the issue by rebooting the server after installing the rke2-selinux rpm package and before performing the rke2 installation.
So he is suggesting updating this specific RKE2 documentation
https://docs.rke2.io/security/selinux
https://docs.rke2.io/install/methods#rpm
Adding a specific mention that a reboot of the server may be required after installing the rke2-selinux package, even if it doesn't apply to 100% of the cases - note that I was not able to reproduce this issue-