### PR TITLE
Add v1.31 release notes page

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,14 +1,16 @@
 name: Collect Release Notes
 on:
-  workflow_dispatch
-
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 6 * * 1' # every Monday at 6:00 AM
 env:
-  MINORS: "v1.27 v1.28 v1.29 v1.30"
+  MINORS: "v1.28 v1.29 v1.30 v1.31"
 permissions:
   contents: write
   pull-requests: write
 jobs:
   collect-all:
+    if: github.repository == 'rancher/rke2-docs'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code

--- a/docs/release-notes/v1.24.X.md
+++ b/docs/release-notes/v1.24.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # v1.24.X

--- a/docs/release-notes/v1.25.X.md
+++ b/docs/release-notes/v1.25.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # v1.25.X

--- a/docs/release-notes/v1.26.X.md
+++ b/docs/release-notes/v1.26.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # v1.26.X

--- a/docs/release-notes/v1.27.X.md
+++ b/docs/release-notes/v1.27.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # v1.27.X
@@ -11,6 +11,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.27.16+rke2r2](v1.27.X.md#release-v12716rke2r2) | Aug 26 2024| [v1.27.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12716) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.20-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.20-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.4-hardened2) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.5](https://github.com/flannel-io/flannel/releases/tag/v0.25.5)<br/>[Calico v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.16.0](https://github.com/cilium/cilium/releases/tag/v1.16.0) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.27.16+rke2r1](v1.27.X.md#release-v12716rke2r1) | Aug 01 2024| [v1.27.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12716) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.27.15+rke2r1](v1.27.X.md#release-v12715rke2r1) | Jul 01 2024| [v1.27.15](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12715) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.27.14+rke2r1](v1.27.X.md#release-v12714rke2r1) | May 22 2024| [v1.27.14](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v12714) | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) | [v1.7.11-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.11-k3s2) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [nginx-1.9.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/nginx-1.9.6-hardened1) | [v0.15.9](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.9) | [Flannel v0.25.1](https://github.com/flannel-io/flannel/releases/tag/v0.25.1)<br/>[Calico v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
@@ -31,6 +32,57 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
+## Release [v1.27.16+rke2r2](https://github.com/rancher/rke2/releases/tag/v1.27.16+rke2r2)
+<!-- v1.27.16+rke2r2 -->
+
+This release updates Kubernetes to v1.27.16.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.27.16+rke2r1:
+
+* Bump nginx to hardened2 [(#6479)](https://github.com/rancher/rke2/pull/6479)
+* Update for CNI flannel, Cilium and Canal [(#6518)](https://github.com/rancher/rke2/pull/6518)
+* Bump k3s and containerd [(#6527)](https://github.com/rancher/rke2/pull/6527)
+* Fixed hns clean only in case of reboot [(#6541)](https://github.com/rancher/rke2/pull/6541)
+* Bump containerd/crictl/runc versions [(#6555)](https://github.com/rancher/rke2/pull/6555)
+* Fix for kill all to not delete the data dir [(#6566)](https://github.com/rancher/rke2/pull/6566)
+* Fix windows airgap image packaging [(#6588)](https://github.com/rancher/rke2/pull/6588)
+* Fixed Flannel chart to rightly disable nft [(#6610)](https://github.com/rancher/rke2/pull/6610)
+* Bump ingress-nginx to v1.10.4-hardened2 [(#6614)](https://github.com/rancher/rke2/pull/6614)
+* Shell completion and etcd connection fix [(#6615)](https://github.com/rancher/rke2/pull/6615)
+* Update Kubernetes v1.27.16 to build 20240819 [(#6589)](https://github.com/rancher/rke2/pull/6589)
+* Bump harvester csi driver v0.1.18 [(#6618)](https://github.com/rancher/rke2/pull/6618)
+  * Bump Harvester-csi-driver v0.1.18
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.16.000](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.16.000.tgz) |
+| rke2-canal | [v3.28.1-build2024080600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.28.1-build2024080600.tgz) |
+| rke2-calico | [v3.27.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.27.300.tgz) |
+| rke2-calico-crd | [v3.27.002](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.27.002.tgz) |
+| rke2-coredns | [1.29.002](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.29.002.tgz) |
+| rke2-ingress-nginx | [4.10.401](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.10.401.tgz) |
+| rke2-metrics-server | [3.12.002](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.12.002.tgz) |
+| rancher-vsphere-csi | [3.3.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.3.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.8.000](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.8.000.tgz) |
+| harvester-cloud-provider | [0.2.400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.400.tgz) |
+| harvester-csi-driver | [0.1.1800](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.1800.tgz) |
+| rke2-snapshot-controller | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-1.7.202.tgz) |
+| rke2-snapshot-controller-crd | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-1.7.202.tgz) |
+| rke2-snapshot-validation-webhook | [1.7.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-1.7.302.tgz) |
+
+
+-----
 ## Release [v1.27.16+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.27.16+rke2r1)
 <!-- v1.27.16+rke2r1 -->
 

--- a/docs/release-notes/v1.28.X.md
+++ b/docs/release-notes/v1.28.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # v1.28.X
@@ -11,6 +11,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.28.13+rke2r1](v1.28.X.md#release-v12813rke2r1) | Aug 26 2024| [v1.28.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v12813) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.20-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.20-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.4-hardened2) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.5](https://github.com/flannel-io/flannel/releases/tag/v0.25.5)<br/>[Calico v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v1.16.0](https://github.com/cilium/cilium/releases/tag/v1.16.0) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.28.12+rke2r1](v1.28.X.md#release-v12812rke2r1) | Aug 01 2024| [v1.28.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v12812) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.28.11+rke2r1](v1.28.X.md#release-v12811rke2r1) | Jul 01 2024| [v1.28.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v12811) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.28.10+rke2r1](v1.28.X.md#release-v12810rke2r1) | May 22 2024| [v1.28.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v12810) | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) | [v1.7.11-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.11-k3s2) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [nginx-1.9.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/nginx-1.9.6-hardened1) | [v0.15.9](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.9) | [Flannel v0.25.1](https://github.com/flannel-io/flannel/releases/tag/v0.25.1)<br/>[Calico v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
@@ -26,6 +27,60 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
+## Release [v1.28.13+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.28.13+rke2r1)
+<!-- v1.28.13+rke2r1 -->
+
+This release updates Kubernetes to v1.28.13.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.28.12+rke2r1:
+
+* Bump rke2-coredns to add option to use nodelocal dns cache with cilium [(#6436)](https://github.com/rancher/rke2/pull/6436)
+* Bump rke2-calico chart to v3.28.100 [(#6485)](https://github.com/rancher/rke2/pull/6485)
+* Bump nginx to hardened2 [(#6480)](https://github.com/rancher/rke2/pull/6480)
+* Update for CNI flannel, Cilium and Canal [(#6517)](https://github.com/rancher/rke2/pull/6517)
+* Fix external etcd connection [(#6463)](https://github.com/rancher/rke2/pull/6463)
+* Rke2 shell completion [(#6462)](https://github.com/rancher/rke2/pull/6462)
+* Bump k3s and containerd [(#6526)](https://github.com/rancher/rke2/pull/6526)
+* Fixed hns clean only in case of reboot [(#6540)](https://github.com/rancher/rke2/pull/6540)
+* Bump harvester csi driver v0.1.18 [(#6393)](https://github.com/rancher/rke2/pull/6393)
+  * Bump Harvester-csi-driver v0.1.18
+* Bump containerd/crictl/runc versions [(#6554)](https://github.com/rancher/rke2/pull/6554)
+* Fix for kill all to not delete the data dir [(#6563)](https://github.com/rancher/rke2/pull/6563)
+* Update Kubernetes to v1.28.13 [(#6572)](https://github.com/rancher/rke2/pull/6572)
+* Fix windows airgap image packaging [(#6587)](https://github.com/rancher/rke2/pull/6587)
+* Fixed Flannel chart to rightly disable nft [(#6609)](https://github.com/rancher/rke2/pull/6609)
+* Bump ingress-nginx to v1.10.4-hardened2 [(#6613)](https://github.com/rancher/rke2/pull/6613)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.16.000](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.16.000.tgz) |
+| rke2-canal | [v3.28.1-build2024080600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.28.1-build2024080600.tgz) |
+| rke2-calico | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.28.100.tgz) |
+| rke2-calico-crd | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.28.100.tgz) |
+| rke2-coredns | [1.29.004](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.29.004.tgz) |
+| rke2-ingress-nginx | [4.10.401](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.10.401.tgz) |
+| rke2-metrics-server | [3.12.002](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.12.002.tgz) |
+| rancher-vsphere-csi | [3.3.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.3.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.8.000](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.8.000.tgz) |
+| harvester-cloud-provider | [0.2.400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.400.tgz) |
+| harvester-csi-driver | [0.1.1800](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.1800.tgz) |
+| rke2-snapshot-controller | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-1.7.202.tgz) |
+| rke2-snapshot-controller-crd | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-1.7.202.tgz) |
+| rke2-snapshot-validation-webhook | [1.7.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-1.7.302.tgz) |
+
+
+-----
 ## Release [v1.28.12+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.28.12+rke2r1)
 <!-- v1.28.12+rke2r1 -->
 

--- a/docs/release-notes/v1.29.X.md
+++ b/docs/release-notes/v1.29.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # v1.29.X
@@ -11,6 +11,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.29.8+rke2r1](v1.29.X.md#release-v1298rke2r1) | Aug 26 2024| [v1.29.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#v1298) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.20-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.20-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.4-hardened2) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.5](https://github.com/flannel-io/flannel/releases/tag/v0.25.5)<br/>[Calico v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v1.16.0](https://github.com/cilium/cilium/releases/tag/v1.16.0) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.29.7+rke2r1](v1.29.X.md#release-v1297rke2r1) | Aug 01 2024| [v1.29.7](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#v1297) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.29.6+rke2r1](v1.29.X.md#release-v1296rke2r1) | Jul 01 2024| [v1.29.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#v1296) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.15.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.10) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.29.5+rke2r1](v1.29.X.md#release-v1295rke2r1) | May 22 2024| [v1.29.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#v1295) | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) | [v1.7.11-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.11-k3s2) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [nginx-1.9.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/nginx-1.9.6-hardened1) | [v0.15.9](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.9) | [Flannel v0.25.1](https://github.com/flannel-io/flannel/releases/tag/v0.25.1)<br/>[Calico v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
@@ -22,6 +23,60 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
+## Release [v1.29.8+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.29.8+rke2r1)
+<!-- v1.29.8+rke2r1 -->
+
+This release updates Kubernetes to v1.29.8.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.29.7+rke2r1:
+
+* Bump rke2-coredns to add option to use nodelocal dns cache with cilium [(#6434)](https://github.com/rancher/rke2/pull/6434)
+* Bump rke2-calico chart to v3.28.100 [(#6487)](https://github.com/rancher/rke2/pull/6487)
+* Bump nginx to hardened2 [(#6481)](https://github.com/rancher/rke2/pull/6481)
+* Update for CNI flannel, Cilium and Canal [(#6516)](https://github.com/rancher/rke2/pull/6516)
+* Fix external etcd connection [(#6464)](https://github.com/rancher/rke2/pull/6464)
+* Rke2 shell completion [(#6461)](https://github.com/rancher/rke2/pull/6461)
+* Bump k3s and containerd [(#6525)](https://github.com/rancher/rke2/pull/6525)
+* Bump Harvester CSI driver v0.1.18 [(#6394)](https://github.com/rancher/rke2/pull/6394)
+  * Bump Harvester-csi-driver v0.1.18
+* Fixed hns clean only in case of reboot [(#6539)](https://github.com/rancher/rke2/pull/6539)
+* Bump containerd/crictl/runc versions [(#6553)](https://github.com/rancher/rke2/pull/6553)
+* Fix for kill all to not delete the data dir [(#6562)](https://github.com/rancher/rke2/pull/6562)
+* Update Kubernetes to v1.29.8 [(#6573)](https://github.com/rancher/rke2/pull/6573)
+* Fix windows airgap image packaging [(#6586)](https://github.com/rancher/rke2/pull/6586)
+* Fixed Flannel chart to rightly disable nft [(#6608)](https://github.com/rancher/rke2/pull/6608)
+* Bump ingress-nginx to v1.10.4-hardened2 [(#6612)](https://github.com/rancher/rke2/pull/6612)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.16.000](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.16.000.tgz) |
+| rke2-canal | [v3.28.1-build2024080600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.28.1-build2024080600.tgz) |
+| rke2-calico | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.28.100.tgz) |
+| rke2-calico-crd | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.28.100.tgz) |
+| rke2-coredns | [1.29.004](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.29.004.tgz) |
+| rke2-ingress-nginx | [4.10.401](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.10.401.tgz) |
+| rke2-metrics-server | [3.12.002](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.12.002.tgz) |
+| rancher-vsphere-csi | [3.3.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.3.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.8.000](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.8.000.tgz) |
+| harvester-cloud-provider | [0.2.400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.400.tgz) |
+| harvester-csi-driver | [0.1.1800](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.1800.tgz) |
+| rke2-snapshot-controller | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-1.7.202.tgz) |
+| rke2-snapshot-controller-crd | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-1.7.202.tgz) |
+| rke2-snapshot-validation-webhook | [1.7.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-1.7.302.tgz) |
+
+
+-----
 ## Release [v1.29.7+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.29.7+rke2r1)
 <!-- v1.29.7+rke2r1 -->
 

--- a/docs/release-notes/v1.30.X.md
+++ b/docs/release-notes/v1.30.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # v1.30.X
@@ -11,6 +11,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.30.4+rke2r1](v1.30.X.md#release-v1304rke2r1) | Aug 26 2024| [v1.30.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v1304) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.20-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.20-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.4-hardened2) | [v0.16.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.1) | [Flannel v0.25.5](https://github.com/flannel-io/flannel/releases/tag/v0.25.5)<br/>[Calico v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v1.16.0](https://github.com/cilium/cilium/releases/tag/v1.16.0) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.30.3+rke2r1](v1.30.X.md#release-v1303rke2r1) | Aug 01 2024| [v1.30.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v1303) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.16.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.1) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.30.2+rke2r1](v1.30.X.md#release-v1302rke2r1) | Jul 01 2024| [v1.30.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v1302) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.17-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.17-k3s1) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.1-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.1-hardened1) | [v0.16.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.1) | [Flannel v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4)<br/>[Calico v3.28.0](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
 | [v1.30.1+rke2r1](v1.30.X.md#release-v1301rke2r1) | May 22 2024| [v1.30.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v1301) | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) | [v1.7.11-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.11-k3s2) | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [nginx-1.9.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/nginx-1.9.6-hardened1) | [v0.16.1-0.20240502205943-2f32059d43e6](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.1-0.20240502205943-2f32059d43e6) | [Flannel v0.25.1](https://github.com/flannel-io/flannel/releases/tag/v0.25.1)<br/>[Calico v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v3.27.3](https://docs.tigera.io/calico/latest/release-notes/#v3.27) | [v1.15.5](https://github.com/cilium/cilium/releases/tag/v1.15.5) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
@@ -18,6 +19,62 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
+## Release [v1.30.4+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.30.4+rke2r1)
+<!-- v1.30.4+rke2r1 -->
+
+This release updates Kubernetes to v1.30.4.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.30.3+rke2r1:
+
+* - Bump rke2-coredns to add option to use nodelocal dns cache with cilium [(#6432)](https://github.com/rancher/rke2/pull/6432)
+* Bump rke2-calico chart to v3.28.100 [(#6489)](https://github.com/rancher/rke2/pull/6489)
+* Bump nginx to hardened2 [(#6482)](https://github.com/rancher/rke2/pull/6482)
+* Update for CNI flannel, Cilium and Canal [(#6515)](https://github.com/rancher/rke2/pull/6515)
+* Fix external etcd connection [(#6465)](https://github.com/rancher/rke2/pull/6465)
+* Rke2 shell completion [(#6460)](https://github.com/rancher/rke2/pull/6460)
+* Bump k3s and containerd [(#6524)](https://github.com/rancher/rke2/pull/6524)
+* Fixed hns clean only in case of reboot [(#6538)](https://github.com/rancher/rke2/pull/6538)
+* Bump harvester csi driver v0.1.18 [(#6395)](https://github.com/rancher/rke2/pull/6395)
+  * Bump Harvester-csi-driver v0.1.18
+* Bump containerd/crictl/runc versions [(#6552)](https://github.com/rancher/rke2/pull/6552)
+* Fix kill all to not delete data dir [(#6564)](https://github.com/rancher/rke2/pull/6564)
+* Add netpol template for traefik [(#6570)](https://github.com/rancher/rke2/pull/6570)
+* Update Kubernetes to v1.30.4 [(#6574)](https://github.com/rancher/rke2/pull/6574)
+* Fix windows airgap image packaging [(#6585)](https://github.com/rancher/rke2/pull/6585)
+* Fixed Flannel chart to rightly disable nft [(#6607)](https://github.com/rancher/rke2/pull/6607)
+* Bump ingress-nginx to v1.10.4-hardened2 [(#6611)](https://github.com/rancher/rke2/pull/6611)
+* Fix traefik netpol port names [(#6620)](https://github.com/rancher/rke2/pull/6620)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.16.000](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.16.000.tgz) |
+| rke2-canal | [v3.28.1-build2024080600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.28.1-build2024080600.tgz) |
+| rke2-calico | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.28.100.tgz) |
+| rke2-calico-crd | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.28.100.tgz) |
+| rke2-coredns | [1.29.004](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.29.004.tgz) |
+| rke2-ingress-nginx | [4.10.401](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.10.401.tgz) |
+| rke2-metrics-server | [3.12.002](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.12.002.tgz) |
+| rancher-vsphere-csi | [3.3.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.3.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.8.000](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.8.000.tgz) |
+| harvester-cloud-provider | [0.2.400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.400.tgz) |
+| harvester-csi-driver | [0.1.1800](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.1800.tgz) |
+| rke2-snapshot-controller | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-1.7.202.tgz) |
+| rke2-snapshot-controller-crd | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-1.7.202.tgz) |
+| rke2-snapshot-validation-webhook | [1.7.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-1.7.302.tgz) |
+
+
+-----
 ## Release [v1.30.3+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.30.3+rke2r1)
 <!-- v1.30.3+rke2r1 -->
 

--- a/docs/release-notes/v1.31.X.md
+++ b/docs/release-notes/v1.31.X.md
@@ -1,0 +1,110 @@
+---
+hide_table_of_contents: true
+sidebar_position: 1
+---
+
+# v1.31.X
+
+:::warning Upgrade Notice
+Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#urgent-upgrade-notes).
+:::
+
+| Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
+| ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.31.0+rke2r1](v1.31.X.md#release-v1310rke2r1) | Sep 04 2024| [v1.31.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1310) | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) | [v1.7.20-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.20-k3s1) | [v1.1.13](https://github.com/opencontainers/runc/releases/tag/v1.1.13) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | [v1.10.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.10.4-hardened2) | [v0.16.3](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.3) | [Flannel v0.25.6](https://github.com/flannel-io/flannel/releases/tag/v0.25.6)<br/>[Calico v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v3.28.1](https://docs.tigera.io/calico/latest/release-notes/#v3.28) | [v1.16.1](https://github.com/cilium/cilium/releases/tag/v1.16.1) | [v4.0.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.0.2) |
+
+<br />
+
+## Release [v1.31.0+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.31.0+rke2r1)
+<!-- v1.31.0+rke2r1 -->
+
+This release updates Kubernetes to v1.31.0.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.30.4+rke2r1:
+
+* Fix RoleBinding/ClusterRoleBinding subject growth [(#6273)](https://github.com/rancher/rke2/pull/6273)
+* Improve agent logs dir default permissions [(#6276)](https://github.com/rancher/rke2/pull/6276)
+* Refactor run_tests.sh script [(#6280)](https://github.com/rancher/rke2/pull/6280)
+* Add e2e test about mixedos+flannel [(#6063)](https://github.com/rancher/rke2/pull/6063)
+* Add `data-dir` to uninstall and killall scripts [(#6296)](https://github.com/rancher/rke2/pull/6296)
+* Bump github.com/hashicorp/go-retryablehttp from 0.7.4 to 0.7.7 [(#6246)](https://github.com/rancher/rke2/pull/6246)
+* Bump alpine from 3.19 to 3.20 [(#6017)](https://github.com/rancher/rke2/pull/6017)
+* Add multiple ingress controller support + traefik [(#5943)](https://github.com/rancher/rke2/pull/5943)
+* Bump multus to v4.0.206 [(#6311)](https://github.com/rancher/rke2/pull/6311)
+* Rke2 shell completion [(#6305)](https://github.com/rancher/rke2/pull/6305)
+  * RKE2 now support shell completion
+* Bump K3s version for master [(#6315)](https://github.com/rancher/rke2/pull/6315)
+* Change fapolicyd rules to full replacement rather than append [(#6309)](https://github.com/rancher/rke2/pull/6309)
+* Bump vsphere csi chart to 3.3.0-rancher100 and cpi to 1.8.000 [(#6340)](https://github.com/rancher/rke2/pull/6340)
+* Upload tarball with merges to master and release branches [(#6316)](https://github.com/rancher/rke2/pull/6316)
+* Add updatecli configuration to update vsphere cpi and csi charts [(#5326)](https://github.com/rancher/rke2/pull/5326)
+* Fix secrets for commit id uploads [(#6359)](https://github.com/rancher/rke2/pull/6359)
+* Fix secrets for commit id uploads [(#6360)](https://github.com/rancher/rke2/pull/6360)
+* Publish binaries in dapper [(#6375)](https://github.com/rancher/rke2/pull/6375)
+* Fix decompressing gh tool in Dockerfile [(#6378)](https://github.com/rancher/rke2/pull/6378)
+* Fixing pat_username [(#6383)](https://github.com/rancher/rke2/pull/6383)
+* Stage CNI (and harvester) images if avaliable for airgap [(#6275)](https://github.com/rancher/rke2/pull/6275)
+* Add missing package windows step in release [(#6387)](https://github.com/rancher/rke2/pull/6387)
+* Add manifest pipeline for rke2-runtime docker image [(#6397)](https://github.com/rancher/rke2/pull/6397)
+* Fix dispatch script [(#6405)](https://github.com/rancher/rke2/pull/6405)
+* Bump rke2-coredns to add option to use nodelocal dns cache with cilium Local Redirect Policy [(#6372)](https://github.com/rancher/rke2/pull/6372)
+* Add traefik airgap image tarball [(#6439)](https://github.com/rancher/rke2/pull/6439)
+* Support Amazon Linux 2 rpm installs [(#6429)](https://github.com/rancher/rke2/pull/6429)
+* Update channel server for July 2024 release [(#6450)](https://github.com/rancher/rke2/pull/6450)
+* Fix external etcd connection [(#6355)](https://github.com/rancher/rke2/pull/6355)
+* Add netpol template for traefik [(#6452)](https://github.com/rancher/rke2/pull/6452)
+* Bump rke2-calico chart to v3.28.100 [(#6473)](https://github.com/rancher/rke2/pull/6473)
+* Bump ingress-nginx to hardened2 [(#6448)](https://github.com/rancher/rke2/pull/6448)
+* Bump rke2-canal to v3.28.1-build2024080600 [(#6496)](https://github.com/rancher/rke2/pull/6496)
+* Update flannel to v0.25.5 [(#6498)](https://github.com/rancher/rke2/pull/6498)
+* Update Cilium to v1.16.0 [(#6500)](https://github.com/rancher/rke2/pull/6500)
+* Bump k3s and containerd [(#6523)](https://github.com/rancher/rke2/pull/6523)
+* Added check if the node is rebooted before the networks is deleted on windows [(#6437)](https://github.com/rancher/rke2/pull/6437)
+* Modify rke2-killall.sh to handle RKE2_DATA_DIR [(#6531)](https://github.com/rancher/rke2/pull/6531)
+* Bump Harvester CSI driver v0.1.18 [(#6392)](https://github.com/rancher/rke2/pull/6392)
+  * Bump Harvester-csi-driver v0.1.18
+* Bump containerd/crictl/runc versions [(#6551)](https://github.com/rancher/rke2/pull/6551)
+* Fix kill all script to not delete data dir [(#6558)](https://github.com/rancher/rke2/pull/6558)
+* Fix traefik netpol annotation key [(#6569)](https://github.com/rancher/rke2/pull/6569)
+* Fix windows airgap image packaging [(#6580)](https://github.com/rancher/rke2/pull/6580)
+* Update to cilium v1.16.1 [(#6577)](https://github.com/rancher/rke2/pull/6577)
+* Fixed Flannel chart to rightly disable nft [(#6606)](https://github.com/rancher/rke2/pull/6606)
+* Bump ingress-nginx to v1.10.4-hardened2 [(#6591)](https://github.com/rancher/rke2/pull/6591)
+* Fix traefik netpol port names [(#6619)](https://github.com/rancher/rke2/pull/6619)
+* Update channel server for August 2024 release [(#6642)](https://github.com/rancher/rke2/pull/6642)
+* Bump canal to v3.28.1-build20240827 [(#6659)](https://github.com/rancher/rke2/pull/6659)
+* Bump runc to v1.1.13 [(#6623)](https://github.com/rancher/rke2/pull/6623)
+* Update Kubernetes to v1.31.0 [(#6625)](https://github.com/rancher/rke2/pull/6625)
+* Bump K8s to v1.31.0-k3s3 [(#6665)](https://github.com/rancher/rke2/pull/6665)
+* Feat: bump harvester-cloud-provider to v0.2.6 [(#6667)](https://github.com/rancher/rke2/pull/6667)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.16.101](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.16.101.tgz) |
+| rke2-canal | [v3.28.1-build2024082701](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.28.1-build2024082701.tgz) |
+| rke2-calico | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.28.100.tgz) |
+| rke2-calico-crd | [v3.28.100](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.28.100.tgz) |
+| rke2-coredns | [1.29.004](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.29.004.tgz) |
+| rke2-ingress-nginx | [4.10.401](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.10.401.tgz) |
+| rke2-metrics-server | [3.12.002](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.12.002.tgz) |
+| rancher-vsphere-csi | [3.3.1-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.3.1-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.9.000](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.9.000.tgz) |
+| harvester-cloud-provider | [0.2.600](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.600.tgz) |
+| harvester-csi-driver | [0.1.1800](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.1800.tgz) |
+| rke2-snapshot-controller | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-1.7.202.tgz) |
+| rke2-snapshot-controller-crd | [1.7.202](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-1.7.202.tgz) |
+| rke2-snapshot-validation-webhook | [1.7.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-1.7.302.tgz) |
+
+
+-----

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@docusaurus/core": "^3.5.2",
     "@docusaurus/plugin-client-redirects": "^3.5.2",
     "@docusaurus/preset-classic": "^3.5.2",
-    "@docusaurus/theme-common": "^3.2.1",
+    "@docusaurus/theme-common": "^3.5.2",
     "@docusaurus/theme-mermaid": "^3.5.2",
     "@easyops-cn/docusaurus-search-local": "^0.44.5",
     "@mdx-js/react": "^3.0.1",
@@ -30,7 +30,7 @@
     "remark-validate-links": "^13.0.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.2.1"
+    "@docusaurus/module-type-aliases": "^3.5.2"
   },
   "browserslist": {
     "production": [

--- a/scripts/collect-all-release-notes.sh
+++ b/scripts/collect-all-release-notes.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+MINORS=${MINORS:-"v1.28 v1.29 v1.30 v1.31"}
+
 function gen_md_link()
 {
     release_link=$(echo $1 | tr '[:upper:]' '[:lower:]' | sed -e 's/ /-/g' -e 's/\.//g' -e 's/+//g')
@@ -50,8 +53,6 @@ function process_cni_table {
         CNI_ROWS+="| ${rows[i]} "
     done
 }
-
-MINORS=${MINORS:-"v1.27 v1.28 v1.29 v1.30"}
 
 for minor in $MINORS; do
     product=rke2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,7 +1511,7 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.5.2", "@docusaurus/module-type-aliases@^3.2.1":
+"@docusaurus/module-type-aliases@3.5.2", "@docusaurus/module-type-aliases@^3.5.2":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz#4e8f9c0703e23b2e07ebfce96598ec83e4dd2a9e"
   integrity sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==
@@ -1708,7 +1708,7 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@3.5.2", "@docusaurus/theme-common@^3.2.1":
+"@docusaurus/theme-common@3.5.2", "@docusaurus/theme-common@^3.5.2":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.5.2.tgz#b507ab869a1fba0be9c3c9d74f2f3d74c3ac78b2"
   integrity sha512-QXqlm9S6x9Ibwjs7I2yEDgsCocp708DrCrgHgKwg2n2AY0YQ6IjU0gAK35lHRLOvAoJUfCKpQAwUykB0R7+Eew==
@@ -9376,16 +9376,7 @@ std-env@^3.0.1:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.4.3.tgz#326f11db518db751c83fd58574f449b7c3060910"
   integrity sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9443,14 +9434,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
- Bump docusaurus/theme-common, dependabot seems to skip this for some reason
- Have the release notes script run every week (if no diff, no PR is opened)