### PR TITLE
Replace dedicated action pull request with gh/git commands

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -27,11 +27,18 @@ jobs:
       - name: Get current month and year
         id: date
         run: echo "month_year=$(date +'%B %Y')" >> $GITHUB_ENV
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: update release-notes/v1.XX.X.md
-          title: Update Release Notes ${{ steps.date.outputs.month_year }}
-          body: Automated release notes update
-          branch: update-release-notes
-          signoff: true
+      - name: Commit release notes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b update-release-notes
+          git add docs/release-notes/*
+          git commit -s -m "update release-notes/v1.XX.X.md"
+          git push -f --set-upstream origin update-release-notes
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create --title "Update release notes for $month_year" \
+          --body "Automated release notes update" --base main --repo ${{ github.repository }}
+


### PR DESCRIPTION
Tested on my fork https://github.com/dereknola/docs-rke2/actions/runs/11670237499 which opened https://github.com/dereknola/docs-rke2/pull/3

Signed-off-by: Derek Nola <derek.nola@suse.com>