### PR TITLE
Add theme-common bump to yarn.lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,7 +1581,7 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@3.6.1", "@docusaurus/theme-common@^3.5.2":
+"@docusaurus/theme-common@3.6.1", "@docusaurus/theme-common@^3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.6.1.tgz#d160516db9482ab19f7921d8a75093885d04d3de"
   integrity sha512-18iEYNpMvarGfq9gVRpGowSZD24vZ39Iz4acqaj64180i54V9el8tVnhNr/wRvrUm1FY30A1NHLqnMnDz4rYEQ==


### PR DESCRIPTION
https://github.com/rancher/rke2-docs/pull/282 Missed the bump necessary to the `yarn.lock` file for the `theme-common` dependency bump.