### PR TITLE
document cilium requirement when enabling wireguard

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -130,7 +130,7 @@ If you wish to utilize the metrics server, you will need to open port 10250 on e
 | 8/0         | ICMP     | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
 | 4240        | TCP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
 | 8472        | UDP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with VXLAN
-| 51871       | UDP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with WireGuard Transparent Encryption
+| 51871       | UDP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with WireGuard
 
 </TabItem>
 <TabItem value="Calico">

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -130,6 +130,7 @@ If you wish to utilize the metrics server, you will need to open port 10250 on e
 | 8/0         | ICMP     | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
 | 4240        | TCP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
 | 8472        | UDP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with VXLAN
+| 51871       | UDP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with WireGuard Transparent Encryption
 
 </TabItem>
 <TabItem value="Calico">


### PR DESCRIPTION
Adding requirement for cilium + wireguard setup.
This port is documented in [cilium doc](https://docs.cilium.io/en/stable/security/network/encryption-wireguard/#encryption-wg)