### PR TITLE
Remove types opened for the test workflow

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
 
 jobs:
   test-deploy:


### PR DESCRIPTION
Remove the "opened" filter to force CI to run the check in each sync on the PR