### PR TITLE
Fix weird encoding issue with -All option

### DIFF
--- a/docs/install/quickstart.md
+++ b/docs/install/quickstart.md
@@ -125,7 +125,7 @@ powershell -Command "Start-Process PowerShell -Verb RunAs"
 
 In the new Powershell window, run the following command to install the containers feature.
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName containers -All
 ```
 This will require a reboot for the `Containers` feature to properly function.
 

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -46,7 +46,7 @@ powershell -Command "Start-Process PowerShell -Verb RunAs"
 
 In the new Powershell window, run the following command.
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName Containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName Containers -All
 ```
 
 This will require a reboot for the `Containers` feature to properly function.

--- a/docs/install/windows_airgap.md
+++ b/docs/install/windows_airgap.md
@@ -24,7 +24,7 @@ powershell -Command "Start-Process PowerShell -Verb RunAs"
 
 In the new Powershell window, run the following command.
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName containers -All
 ```
 This will require a reboot for the `Containers` feature to properly function.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/quickstart.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/quickstart.md
@@ -140,7 +140,7 @@ powershell -Command "Start-Process PowerShell -Verb RunAs"
 
 在新的 Powershell 窗口中，运行以下命令：
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName containers -All
 ```
 需要重启才能使 `Containers` 功能正常运行。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
@@ -58,7 +58,7 @@ powershell -Command "Start-Process PowerShell -Verb RunAs"
 
 在新的 Powershell 窗口中，运行以下命令：
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName Containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName Containers -All
 ```
 
 需要重启才能使 `Containers` 功能正常运行。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/windows_airgap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/windows_airgap.md
@@ -25,7 +25,7 @@ powershell -Command "Start-Process PowerShell -Verb RunAs"
 
 在新的 Powershell 窗口中，运行以下命令：
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName containers -All
 ```
 需要重启才能使 `Containers` 功能正常运行。
 


### PR DESCRIPTION
Fixing an encoding issue when copy/paste is performed from the documentation.

```
A positional parameter cannot be found that accepts argument '\xe2\x80\x93All'.\
```