### PR TITLE
cluster-dns add IPv6 to the documentation

### DIFF
--- a/docs/reference/server_config.md
+++ b/docs/reference/server_config.md
@@ -37,7 +37,7 @@ The following options must be set to the same value on all servers in the cluste
 | cluster-cidr | IPv4/IPv6 network CIDRs to use for pod IPs  | 10.42.0.0/16 |  |
 | service-cidr | IPv4/IPv6 network CIDRs to use for service IPs  | 10.43.0.0/16 |  |
 | service-node-port-range | Port range to reserve for services with NodePort visibility  | "30000-32767" |  |
-| cluster-dns | IPv4 Cluster IP for coredns service. Should be in your service-cidr range  | 10.43.0.10 |  |
+| cluster-dns | IPv4/IPv6 Cluster IP for coredns service. Should be in your service-cidr range  | 10.43.0.10 |  |
 | cluster-domain | Cluster Domain  | "cluster.local" |  |
 | egress-selector-mode | One of 'agent', 'cluster', 'pod', 'disabled'  | "agent" |  |
 | servicelb-namespace | Namespace of the pods for the servicelb component  | "kube-system" |  |


### PR DESCRIPTION
Although RKE2 cluster DNS supports both IPv4 and IPv6, the documentation does not currently mention the option to use an IPv6 address for the cluster DNS. Similarly, users can specify an IPv4, IPv6, or dual-stack address for the cluster DNS.

https://github.com/rancher/rke2/blob/9255fd8fa411695fc93573a6e6dfa9470e13e938/scripts/validate-charts#L54