### PR TITLE
Change serviceLb to enable-servicelb

### DIFF
--- a/docs/networking/networking_services.md
+++ b/docs/networking/networking_services.md
@@ -124,4 +124,4 @@ Kubernetes Services can be of type LoadBalancer but it requires an external load
 When looking at the K3s documentation, use the label `svccontroller.rke2.cattle.io` instead of `svccontroller.k3s.cattle.io` where applicable.
 :::
 
-To enable serviceLB, use the flag `--serviceLB` when deploying RKE2.
+To enable serviceLB, use the flag `--enable-servicelb` when deploying RKE2.


### PR DESCRIPTION
I was trying to install some LB on my baremetal deployment when I learnt about `serviceLb`
The correct command seems to be `--enable-servicelb`. Updated that in the docs.
![image](https://github.com/user-attachments/assets/a9bacdb9-1a07-4129-a9bb-aeb4cf81b400)
