### PR TITLE
Cleanup instructions for Spegel, remove flag references.

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -220,12 +220,12 @@ The following options are available under the `server` sub-command for RKE2. The
 
 | Flag | ENV VAR | 
 | --- | --- |
-| `--kube-apiserver-extra-mount` | RKE2_KUBE_APISERVER_EXTRA_MOUNT | kube-apiserver extra volume mounts |
-| `--kube-scheduler-extra-mount` | RKE2_KUBE_SCHEDULER_EXTRA_MOUNT | kube-scheduler extra volume mounts |
-| `--kube-controller-manager-extra-mount` | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_MOUNT |
-| `--kube-proxy-extra-mount` | RKE2_KUBE_PROXY_EXTRA_MOUNT |
-| `--etcd-extra-mount` | RKE2_ETCD_EXTRA_MOUNT |
-| `--cloud-controller-manager-extra-mount` | RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_MOUNT |
+| kube-apiserver-extra-mount | RKE2_KUBE_APISERVER_EXTRA_MOUNT | kube-apiserver extra volume mounts |
+| kube-scheduler-extra-mount | RKE2_KUBE_SCHEDULER_EXTRA_MOUNT | kube-scheduler extra volume mounts |
+| kube-controller-manager-extra-mount | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_MOUNT |
+| kube-proxy-extra-mount | RKE2_KUBE_PROXY_EXTRA_MOUNT |
+| etcd-extra-mount | RKE2_ETCD_EXTRA_MOUNT |
+| cloud-controller-manager-extra-mount | RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_MOUNT |
 
 
 ### RW Host Path Volume Mount
@@ -250,16 +250,16 @@ kube-apiserver-extra-mount:
 
 ## Extra Control Plane Component Environment Variables
 
-The following options are available under the `server` sub-command for RKE2. These options specify additional environment variables in standard format i.e. `KEY=VALUE` for the static pod component that corresponds to the prefixed name.
+The following configuration options are available to the `server` sub-command for RKE2. These options specify additional environment variables in standard format i.e. `KEY=VALUE` for the static pod component that corresponds to the prefixed name.
 
 | Flag | ENV VAR |
 | --- | --- |
-| `--kube-apiserver-extra-env` | RKE2_KUBE_APISERVER_EXTRA_ENV |
-| `--kube-scheduler-extra-env` | RKE2_KUBE_SCHEDULER_EXTRA_ENV |
-| `--kube-controller-manager-extra-env` | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_ENV |
-| `--kube-proxy-extra-env` | RKE2_KUBE_PROXY_EXTRA_ENV |
-| `--etcd-extra-env` | RKE2_ETCD_EXTRA_ENV |
-| `--cloud-controller-manager-extra-env` | RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV |
+| kube-apiserver-extra-env | RKE2_KUBE_APISERVER_EXTRA_ENV |
+| kube-scheduler-extra-env | RKE2_KUBE_SCHEDULER_EXTRA_ENV |
+| kube-controller-manager-extra-env | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_ENV |
+| kube-proxy-extra-env | RKE2_KUBE_PROXY_EXTRA_ENV |
+| etcd-extra-env | RKE2_ETCD_EXTRA_ENV |
+| cloud-controller-manager-extra-env | RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV |
 
 Multiple environment variables can be specified for the same component by passing the flag values as an array in the config file.
 

--- a/docs/install/ha.md
+++ b/docs/install/ha.md
@@ -75,8 +75,8 @@ Note: The NGINX Ingress and Metrics Server addons will **not** be deployed when 
 ### 3. Launch additional server nodes
 Additional server nodes are launched much like the first, except that you must specify the `server` and `token` parameters so that they can successfully connect to the initial server node.
 
-:::info Matching Flags
-It is important to match critical flags on your server nodes. For example, if you use the flag `--cluster-cidr=10.200.0.0/16` on your first server node, but don't set it on other server nodes, the nodes will fail to join. They will print errors such as: `failed to validate server configuration: critical configuration value mismatch.`
+:::info Matching Configuration
+It is important to match critical flags on your server nodes. For example, if you use the flag `cluster-cidr: 10.200.0.0/16` on your first server node, but don't set it on other server nodes, the nodes will fail to join. They will print errors such as: `failed to validate server configuration: critical configuration value mismatch.`
 See [Server Configuration](../reference/server_config.md#critical-configuration-values) for more information on which flags must be set identically on server nodes.
 :::
 
@@ -93,7 +93,7 @@ tls-san:
 
 As mentioned previously, you must have an odd number of server nodes in total.
 
-If an etcd datastore is found on disk either because that node has either initialized or joined a cluster already, the argument `--server` is ignored.
+If an etcd datastore is found on disk either because that node has either initialized or joined a cluster already, the configuration `server: <XXX>` is ignored.
 
 ### 4. Confirm cluster is functional
 Once you've launched the `rke2 server` process on all server nodes, ensure that the cluster has come up properly with

--- a/docs/install/registry_mirror.md
+++ b/docs/install/registry_mirror.md
@@ -10,7 +10,7 @@ RKE2 embeds [Spegel](https://github.com/spegel-org/spegel), a stateless distribu
 
 ## Enabling The Distributed OCI Registry Mirror
 
-In order to enable the embedded registry mirror, server nodes must be started with the `--embedded-registry` flag, or with `embedded-registry: true` in the configuration file.
+In order to enable the embedded registry mirror, server nodes must be configured with `embedded-registry: true`.
 This option enables the embedded mirror for use on all nodes in the cluster.
 
 When enabled at a cluster level, all nodes will host a local OCI registry on port 6443,
@@ -23,6 +23,16 @@ ensure that they remain available and are not pruned by Kubelet garbage collecti
 
 When the embedded registry mirror is enabled, all nodes must be able to reach each other via their internal IP addresses, on TCP ports 5001 and 9345.
 If nodes cannot reach each other, it may take longer for images to be pulled, as the distributed registry will be tried first by containerd, before it falls back to other endpoints.
+
+### Metrics
+
+Spegel provides a few metrics that can be helpful to track its activity and can be queried in the supervisor. However, the supervisor metrics are disabled by default. To enable them, server nodes must be started with `supervisor-metrics: true` in the configuration file.
+
+Once enabled, query:
+
+```
+kubectl get --server https://$SERVER_NAME:9345 --raw /metrics | grep spegel
+```
 
 ## Enabling Registry Mirroring
 
@@ -75,7 +85,7 @@ By default, containerd will fall back to the default endpoint when pulling from 
 and only pull images from the configured mirrors and/or the embedded mirror, see the [Default Endpoint Fallback](./private_registry.md#default-endpoint-fallback)
 section of the Private Registry Configuration documentation.
 
-Note that if you are using the `--disable-default-endpoint` option and want to allow pulling directly from a particular registry, while disallowing the rest,
+Note that if you are using the `disable-default-endpoint` option and want to allow pulling directly from a particular registry, while disallowing the rest,
 you can explicitly provide an endpoint in order to allow the image pull to fall back to the registry itself:
 ```yaml
 mirrors:
@@ -139,12 +149,4 @@ Images can be manually made available via the embedded registry by running `ctr 
 or by loading image archives created by `docker save` via the `ctr -n k8s.io image import` command.
 Note that the `k8s.io` namespace must be specified when managing images via `ctr` in order for them to be visible to the kubelet.
 
-## Metrics
 
-Spegel provides a few metrics that can be helpful to track its activity and can be queried in the supervisor. However, the supervisor metrics are disabled by default. To enable them, server nodes must be started with the `--supervisor-metrics` flag, or with `supervisor-metrics: true` in the configuration file.
-
-Once enabled, query:
-
-```
-kubectl get --server https://$SERVER_NAME:9345 --raw /metrics | grep spegel
-```


### PR DESCRIPTION
Some confusion over how to properly configure Spegel in rancher prompted a second pass over these docs.
- Remove references to flag configs (ie `--flag`). Thats not how 99% of people control RKE2.
- Move Metrics up the page and put it as a subsection just after "Enabling". Hopefully people will see this sooner and know that they want
```
embedded-registry: true
supervisor-metrics: true
```
Right from the start, instead of having them realize it later and need to restart all their clusters.