### PR TITLE
Add architecture in the installation requirements

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -20,6 +20,10 @@ The `with-node-id` parameter is available starting with the 2023-05 releases (v1
 
 :::
 
+## Architecture
+
+RKE2 is available for x86_64 and arm64/aarch64
+
 ## Operating Systems
 
 ### Linux


### PR DESCRIPTION
Nothing in the docs was mentioning the CPU architectures we support