### PR TITLE
Clarified warning in backup_restore.md

### DIFF
--- a/docs/datastore/backup_restore.md
+++ b/docs/datastore/backup_restore.md
@@ -2,7 +2,7 @@
 title: Backup and Restore
 ---
 
-:::warning Backup and restore for external databases or sqlite
+:::warning If using external databases or sqlite
 Snapshots are for embedded etcd only, if you use another datastore with `datastore-endpoint` config go to [Experimental](backup_restore.md#external-db-backups-experimental)
 :::
 


### PR DESCRIPTION
The warning heading appeared to be saying that this was the page for the "Backup and restore for external databases or sqlite" when it was actually just the heading for the warning to those using databases other than etcd.  I clarified by moving it to an if statement meant to draw in the passing glance of those using these databases.