### PR TITLE
Add information about the expiration date of certificates

### DIFF
--- a/docs/security/certificates.md
+++ b/docs/security/certificates.md
@@ -6,6 +6,35 @@ title: Certificate Management
 
 RKE2 client and server certificates are valid for 365 days from their date of issuance. Any certificates that are expired, or within 90 days of expiring, are automatically renewed every time RKE2 starts.
 
+:::info CERTIFICATE EXPIRATION WARNING
+When a certificate is within 90 days of expiring a Kubernetes Warning event with reason: `CertificateExpirationWarning` is created
+:::
+
+
+### Checking expiration dates
+
+To check the node certificates and their expiration date use the `rke2 certificate check --output table`:
+
+```bash
+CERTIFICATE                 SUBJECT                                            STATUS  EXPIRES
+-----------                 -------                                            ------  -------
+client-kube-proxy.crt       CN=system:kube-proxy                               OK      2026-04-03T10:50:43Z
+client-kube-proxy.crt       CN=rke2-client-ca@1743677343                       OK      2035-04-01T10:49:03Z
+client-kubelet.crt          CN=system:node:vm1,O=system:nodes                  OK      2026-04-03T10:50:43Z
+client-kubelet.crt          CN=rke2-client-ca@1743677343                       OK      2035-04-01T10:49:03Z
+serving-kubelet.crt         CN=vm1                                             OK      2026-04-03T10:50:43Z
+serving-kubelet.crt         CN=rke2-server-ca@1743677343                       OK      2035-04-01T10:49:03Z
+client-rke2-controller.crt  CN=system:rke2-controller                          OK      2026-04-03T10:50:43Z
+client-rke2-controller.crt  CN=rke2-client-ca@1743677343                       OK      2035-04-01T10:49:03Z
+```
+
+:::info SAME CERTIFICATE TWICE
+Each certificate file (CERTIFICATE column) contains two certificates, including the certificate itself and its issuing Certificate Authority (CA)
+:::
+
+In case of unexpected output, please use `--debug` flag to get more information or configure the correct data directory with `--data-dir` flag.
+
+
 ### Rotating Client and Server Certificates Manually
 
 To rotate client and server certificates manually, use the `rke2 certificate rotate` subcommand:

--- a/docs/security/hardening_guide.md
+++ b/docs/security/hardening_guide.md
@@ -128,7 +128,7 @@ When the `profile` flag is set it does the following:
 
 1. Checks that host-level requirements have been met. If they haven't, RKE2 will exit with a fatal error describing the unmet requirements.
 
-2. Configures the etcd static pod to run as the etcd user and group, as explained in the [etcd hardedning guide](https://docs.rke2.io/security/hardening_guide#etcd-is-configured-properly)
+2. Configures the etcd static pod to run as the etcd user and group, as explained in the [etcd hardening guide](https://docs.rke2.io/security/hardening_guide#etcd-is-configured-properly)
 
 3. Applies network policies that allow the cluster to pass associated controls.
 


### PR DESCRIPTION
Add missing information about the "rke2 certificate expiration" command in the docs. Same as in K3s. 

It also fixes a stupid typo I added in a previous PR