### PR TITLE
Add comments to example upgrade manifest

### DIFF
--- a/docs/upgrades/automated_upgrade.md
+++ b/docs/upgrades/automated_upgrade.md
@@ -90,10 +90,13 @@ spec:
   nodeSelector:
     matchExpressions:
       - {key: beta.kubernetes.io/os, operator: In, values: ["linux"]}
-      - {key: rke2-upgrade, operator: Exists}
-      - {key: rke2-upgrade, operator: NotIn, values: ["disabled", "false"]}
       # When using k8s version 1.19 or older, swap control-plane with master
       - {key: node-role.kubernetes.io/control-plane, operator: NotIn, values: ["true"]}
+      # Optionally limit the upgrade to nodes that have an "rke2-upgrade" label, and
+      # exclude nodes where the label value is "disabled" or "false". To upgrade all
+      # agent nodes, remove the following two items.
+      - {key: rke2-upgrade, operator: Exists}
+      - {key: rke2-upgrade, operator: NotIn, values: ["disabled", "false"]}
   prepare:
     args:
     - prepare

--- a/docs/upgrades/automated_upgrade.md
+++ b/docs/upgrades/automated_upgrade.md
@@ -89,7 +89,7 @@ spec:
   concurrency: 2
   nodeSelector:
     matchExpressions:
-      - {key: beta.kubernetes.io/os, operator: In, values: ["linux"]}
+      - {key: kubernetes.io/os, operator: In, values: ["linux"]}
       # When using k8s version 1.19 or older, swap control-plane with master
       - {key: node-role.kubernetes.io/control-plane, operator: NotIn, values: ["true"]}
       # Optionally limit the upgrade to nodes that have an "rke2-upgrade" label, and


### PR DESCRIPTION
Add comments to the example agent upgrade Plan manifest. The comments indicate that part of the example filter is optional and will exclude some nodes, mirroring explanatory notes below the example, and instruct users to delete them to include all agent nodes in the plan.

I also moved that example to the end of the list, to hopefully avoid accidentally deleting the selector that excludes server nodes.

Related to https://github.com/rancher/system-upgrade-controller/issues/217