### PR TITLE
Remove Windows-Flannel experimental

### DIFF
--- a/docs/networking/basic_network_options.md
+++ b/docs/networking/basic_network_options.md
@@ -203,10 +203,6 @@ spec:
 Flannel does not support network policies. Therefore, it is not recommended for hardened installations.
 :::
 
-:::warning
-Flannel support in RKE2 is currently experimental. Do not run it on production systems without extensive testing.
-:::
-
 </TabItem>
 </Tabs>
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/networking/basic_network_options.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/networking/basic_network_options.md
@@ -162,9 +162,6 @@ Only vxlan backend is supported at this point
 :::warning
 Flannel does not support network policies. Therefore, it is not recommended for hardened installations
 :::
-:::warning
-Flannel support in RKE2 is currently experimental. Do not run it on production systems before extensive testing
-:::
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Users have been running Windows and Flannel for more than a year and QA is rigorously testing it, so we can consider it stable