### PR TITLE
Ports 6443 & 9345 must be open from all nodes, not just agent nodes

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -109,8 +109,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | Port        | Protocol | Source            | Destination       | Description
 |-------------|----------|-------------------|-------------------|------------
-| 6443        | TCP      | RKE2 agent nodes  | RKE2 server nodes | Kubernetes API
-| 9345        | TCP      | RKE2 agent nodes  | RKE2 server nodes | RKE2 supervisor API
+| 6443        | TCP      | All RKE2 nodes    | RKE2 server nodes | Kubernetes API
+| 9345        | TCP      | All RKE2 nodes    | RKE2 server nodes | RKE2 supervisor API
 | 10250       | TCP      | All RKE2 nodes    | All RKE2 nodes    | kubelet metrics
 | 2379        | TCP      | RKE2 server nodes | RKE2 server nodes | etcd client port
 | 2380        | TCP      | RKE2 server nodes | RKE2 server nodes | etcd peer port


### PR DESCRIPTION
The table says ports 6443 & 9345 need to be open to just agent nodes, but my firewall logs show that the server (controlplane) nodes also need to reach these ports on their fellow controlplane nodes.

Also, this sentence above suggests that the ports need to be open to all nodes:

> The RKE2 server needs port 6443 and 9345 to be accessible by other nodes in the cluster.

# Evidence:

When provisioning a downstream cluster, I only opened these ports to the agent nodes. My contolplane nodes are named cp01, cp02, cp03 with IPs ending in 101, 102, 103. cp02 was selected as the 'bootstrap' node. The other two controlplane nodes could not join because their connections were being blocked by the firewall. Here are some abbreviated logs.

```
2025-07-28T14:24:30 cp02 kernel: DROP-INPUT: IN=ens192 OUT= MAC=REDACTED SRC=192.168.100.101 DST=192.168.100.102 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=47223 DF PROTO=TCP SPT=53292 DPT=9345
2025-07-28T14:25:41 cp02 kernel: DROP-INPUT: IN=ens192 OUT= MAC=REDACTED SRC=192.168.100.103 DST=192.168.100.102 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=2253 DF PROTO=TCP SPT=50906 DPT=6443
```

OS: Ubuntu 24.04