### PR TITLE
Added section on how to configure windows with Calico BGP

### DIFF
--- a/docs/networking/windows_bgp.md
+++ b/docs/networking/windows_bgp.md
@@ -1,0 +1,59 @@
+---
+title: Windows and BGP
+---
+
+
+## Enabling BGP on Calico with Windows
+
+To enable BGP mode for routing traffic with RKE2 using both Linux and Windows nodes, the Calico CNI should be selected in the Server configuration.
+
+```yaml
+# /etc/rancher/rke2/config.yaml
+cni: calico
+```
+
+Calico should then be configured with BGP enabled and encapsulation set to `None`.
+
+```yaml
+# /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-calico
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    installation:
+      calicoNetwork:
+        bgp: Enabled
+      backend: "None"
+```
+
+## Starting Windows node
+
+Configure RKE2 on the Windows node as described [here](../install/quickstart.md#windows-agent-worker-node-installation).
+
+Before starting the RKE2 service, `RemoteAccess` must be enabled.
+
+```powershell
+Install-WindowsFeature RemoteAccess
+Install-WindowsFeature RSAT-RemoteAccess-PowerShell
+Install-WindowsFeature Routing
+```
+
+This requires a reboot to function properly.
+
+Next, configure the `RemoteAccess` service:
+
+```powershell
+Install-RemoteAccess -VpnType RoutingOnly
+```
+
+To check if the `RemoteAccess` service has started properly, use the following command:
+
+```powershell
+Start-Service RemoteAccess
+```
+
+After that, you can start the RKE2 service.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/networking/windows_bgp.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/networking/windows_bgp.md
@@ -1,0 +1,59 @@
+---
+title: Windows and BGP
+---
+
+
+## Enabling BGP on Calico with Windows
+
+To enable BGP mode for routing traffic with RKE2 using both Linux and Windows nodes, the Calico CNI should be selected in the Server configuration.
+
+```yaml
+# /etc/rancher/rke2/config.yaml
+cni: calico
+```
+
+Calico should then be configured with BGP enabled and encapsulation set to `None`.
+
+```yaml
+# /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-calico
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    installation:
+      calicoNetwork:
+        bgp: Enabled
+      backend: "None"
+```
+
+## Starting Windows node
+
+Configure RKE2 on the Windows node as described [here](../install/quickstart.md#windows-agent-worker-node-installation).
+
+Before starting the RKE2 service, `RemoteAccess` must be enabled.
+
+```powershell
+Install-WindowsFeature RemoteAccess
+Install-WindowsFeature RSAT-RemoteAccess-PowerShell
+Install-WindowsFeature Routing
+```
+
+This requires a reboot to function properly.
+
+Next, configure the `RemoteAccess` service:
+
+```powershell
+Install-RemoteAccess -VpnType RoutingOnly
+```
+
+To check if the `RemoteAccess` service has started properly, use the following command:
+
+```powershell
+Start-Service RemoteAccess
+```
+
+After that, you can start the RKE2 service.

--- a/sidebars.js
+++ b/sidebars.js
@@ -73,6 +73,7 @@ module.exports = {
         'networking/basic_network_options',
         'networking/multus_sriov',
         'networking/networking_services',
+        'networking/windows_bgp',
       ],
     },
     'helm',


### PR DESCRIPTION
This PR adds an additional section on the networking tab with the commands needed to configure Calico with BGP with Windows nodes.