### PR TITLE
Add global site tag for Google Analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,8 +120,9 @@ module.exports = {
         theme: {
           customCss: [require.resolve("./src/css/custom.css")],
         },
-        googleTagManager: {
-          containerId: 'GTM-57KS2MW',
+        gtag: {
+          trackingID: "GTM-57KS2MW", // Global site tag for Google Analytics
+          anonymizeIP: true,
         },
       },
     ],


### PR DESCRIPTION
Changes:

- Add global site tag for Google Analytics (Reference: [plugin-google-gtag](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag))
- Remove deprecated Google Analytics plugin (Reference: [plugin-google-analytics](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics))