### PR TITLE
Mention that proxy vars are passed to managed pods

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -72,7 +72,7 @@ For best results, do NOT simply copy a prerendered `config.toml` into the templa
 
 ## Configuring an HTTP proxy
 
-If you are running RKE2 in an environment, which only has external connectivity through an HTTP proxy, you can configure your proxy settings on the RKE2 systemd service. These proxy settings will then be used in RKE2 and passed down to the embedded containerd and kubelet.
+If you are running RKE2 in an environment, which only has external connectivity through an HTTP proxy, you can configure your proxy settings on the RKE2 systemd service. These proxy settings will then be used in RKE2 and passed down to the embedded containerd and kubelet, as well as the control-plane, etcd, and kube-proxy static pods.
 
 Add the necessary `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` variables to the environment file of your systemd service, usually:
 


### PR DESCRIPTION
Apparently we've always done this 🤷🏻 

https://github.com/rancher/rke2/blame/a9a0c194cbd38117b034ddd09ff7a4da0c8efe46/pkg/staticpod/staticpod.go#L273-L277