### PR TITLE
Add existing cluster note for dual-stack configuration

### DIFF
--- a/docs/networking/basic_network_options.md
+++ b/docs/networking/basic_network_options.md
@@ -229,6 +229,8 @@ cluster-cidr: "10.42.0.0/16,2001:cafe:42::/56"
 service-cidr: "10.43.0.0/16,2001:cafe:43::/112"
 ```
 
+Dual-stack networking must be configured when the cluster is first created. It cannot be enabled on an existing cluster once it has been started as IPv4-only.
+
 Each CNI Plugin may require a different configuration for dual-stack:
 
 <Tabs groupId="CNIplugin" queryString>


### PR DESCRIPTION
In line with the k3s documentation it is helpful to note that changing an existing cluster to dual-stack is not supported
  * https://docs.k3s.io/networking/basic-network-options#dual-stack-ipv4--ipv6-networking

Please adjust as needed