### PR TITLE
Revert "Add global site tag for Google Analytics"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,9 +117,8 @@ module.exports = {
         theme: {
           customCss: [require.resolve("./src/css/custom.css")],
         },
-        gtag: {
-          trackingID: "GTM-57KS2MW", // Global site tag for Google Analytics
-          anonymizeIP: true,
+        googleTagManager: {
+          containerId: 'GTM-57KS2MW',
         },
       },
     ],


### PR DESCRIPTION
Reverts rancher/rke2-docs#399

Per community analytics slack discussion, use GTM script generated by: 

```
googleTagManager: {
  containerId: 'GTM-XXXXXXX',
},
```