### PR TITLE
Add v1.34 release notes page

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18' # Install Node.js version 18
 

--- a/.github/workflows/browserlist.yml
+++ b/.github/workflows/browserlist.yml
@@ -1,0 +1,37 @@
+name: Update Browserslist
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 6 3 * *' # Every 3rd day of Month at 6:00 AM
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  browserlist:
+    if: github.repository == 'rancher/rke2-docs'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Update Browserlist
+        run: npx update-browserslist-db@latest
+      - name: Get current month and year
+        id: date
+        run: echo "month_year=$(date +'%B %Y')" >> $GITHUB_OUTPUT
+      - name: Commit browserlist update
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b update-browserslist-db
+          git commit -s -m "Update Browsers List DB ${{ steps.date.outputs.month_year }}"
+          git push -f --set-upstream origin pdate-browserslist-db
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create --title "Update Browsers List DB ${{ steps.date.outputs.month_year }}" \
+          --body " Automated npx update-browserslist-db@latest" --base main --repo ${{ github.repository }}

--- a/.github/workflows/browserlist.yml
+++ b/.github/workflows/browserlist.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
       - name: Update Browserlist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: yarn

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,8 +24,6 @@ jobs:
         run: scripts/collect-all-release-notes.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update Browser List
-        run: npx update-browserslist-db@latest
       - name: Get current month and year
         id: date
         run: echo "month_year=$(date +'%B %Y')" >> $GITHUB_ENV

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Enable Corepack for Modern Yarn
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: yarn

--- a/docs/release-notes-old/v1.24.X.md
+++ b/docs/release-notes-old/v1.24.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 5
+sidebar_position: 6
 title: v1.24.X
 ---
 

--- a/docs/release-notes-old/v1.25.X.md
+++ b/docs/release-notes-old/v1.25.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 4
+sidebar_position: 5
 title: v1.25.X
 ---
 

--- a/docs/release-notes-old/v1.26.X.md
+++ b/docs/release-notes-old/v1.26.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 3
+sidebar_position: 4
 title: v1.26.X
 ---
 

--- a/docs/release-notes-old/v1.27.X.md
+++ b/docs/release-notes-old/v1.27.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 2
+sidebar_position: 3
 title: v1.27.X
 ---
 

--- a/docs/release-notes-old/v1.28.X.md
+++ b/docs/release-notes-old/v1.28.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 1
+sidebar_position: 2
 title: v1.28.X
 ---
 

--- a/docs/release-notes-old/v1.29.X.md
+++ b/docs/release-notes-old/v1.29.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 5
+sidebar_position: 1
 title: v1.29.X
 ---
 

--- a/docs/release-notes/v1.30.X.md
+++ b/docs/release-notes/v1.30.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 4
+sidebar_position: 5
 title: v1.30.X
 ---
 

--- a/docs/release-notes/v1.31.X.md
+++ b/docs/release-notes/v1.31.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 3
+sidebar_position: 4
 title: v1.31.X
 ---
 
@@ -11,6 +11,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.31.13+rke2r1](v1.31.X.md#release-v13113rke2r1) | Sep 18 2025| [v1.31.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13113) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.1.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.1.4-k3s2) | [v1.3.1](https://github.com/opencontainers/runc/releases/tag/v1.3.1) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | [v1.12.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.6-hardened1) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.3](https://github.com/flannel-io/flannel/releases/tag/v0.27.3)<br/>[Calico v3.30.3](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.3 ](https://docs.tigera.io/calico/latest/release-notes/#v3.30.3 ) | [v1.18.1](https://github.com/cilium/cilium/releases/tag/v1.18.1) | [v4.2.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2) |
 | [v1.31.12+rke2r1](v1.31.X.md#release-v13112rke2r1) | Aug 23 2025| [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13112) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | [v1.12.4-hardened7](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.4-hardened7) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.2](https://github.com/flannel-io/flannel/releases/tag/v0.27.2)<br/>[Calico v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.18.0](https://github.com/cilium/cilium/releases/tag/v1.18.0) | [v4.2.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2) |
 | [v1.31.11+rke2r1](v1.31.X.md#release-v13111rke2r1) | Jul 25 2025| [v1.31.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13111) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2) | [v1.12.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.4-hardened2) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.1](https://github.com/flannel-io/flannel/releases/tag/v0.27.1)<br/>[Calico v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.17.6](https://github.com/cilium/cilium/releases/tag/v1.17.6) | [v4.2.1](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.1) |
 | [v1.31.10+rke2r1](v1.31.X.md#release-v13110rke2r1) | Jun 27 2025| [v1.31.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13110) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) | [v1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2) | [v1.12.2-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.2-hardened2) | [v0.16.11](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.11) | [Flannel v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0)<br/>[Calico v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.17.4](https://github.com/cilium/cilium/releases/tag/v1.17.4) | [v4.2.1](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.1) |
@@ -27,6 +28,56 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
+## Release [v1.31.13+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.31.13+rke2r1)
+<!-- v1.31.13+rke2r1 -->
+
+This release updates Kubernetes to v1.31.13.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.31.12+rke2r1:
+
+* Added Calico new images [(#8831)](https://github.com/rancher/rke2/pull/8831)
+* Added Cilium with wireguard e2e tests [(#8816)](https://github.com/rancher/rke2/pull/8816)
+* CNI and coredns bumps for Sep 25 release [(#8849)](https://github.com/rancher/rke2/pull/8849)
+* Bump k3s, containerd, runc [(#8867)](https://github.com/rancher/rke2/pull/8867)
+* Bump crictl and cloud provider [(#8864)](https://github.com/rancher/rke2/pull/8864)
+* Bump ingress-nginx v1.12.6-hardened1 [(#8871)](https://github.com/rancher/rke2/pull/8871)
+* Bump CNI chart latest version [(#8885)](https://github.com/rancher/rke2/pull/8885)
+* Update metrics-server chart 3.13.001 [(#8906)](https://github.com/rancher/rke2/pull/8906)
+* Update CoreDNS chart 1.43.302 [(#8910)](https://github.com/rancher/rke2/pull/8910)
+* Bump etcd [(#8913)](https://github.com/rancher/rke2/pull/8913)
+* Update to v1.31.13 and Go v1.23.12 [(#8916)](https://github.com/rancher/rke2/pull/8916)
+* Bump vsphere charts [(#8941)](https://github.com/rancher/rke2/pull/8941)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.18.103](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.18.103.tgz) |
+| rke2-canal | [v3.30.3-build2025090900](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.30.3-build2025090900.tgz) |
+| rke2-calico | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.30.300.tgz) |
+| rke2-calico-crd | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.30.300.tgz) |
+| rke2-coredns | [1.43.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.43.302.tgz) |
+| rke2-ingress-nginx | [4.12.600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.12.600.tgz) |
+| rke2-metrics-server | [3.13.001](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.001.tgz) |
+| rancher-vsphere-csi | [3.5.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.12.100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz) |
+| harvester-cloud-provider | [0.2.1000](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1000.tgz) |
+| harvester-csi-driver | [0.1.2400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2400.tgz) |
+| rke2-snapshot-controller | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.0.003.tgz) |
+| rke2-snapshot-controller-crd | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.0.003.tgz) |
+| rke2-snapshot-validation-webhook | [0.0.0](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-0.0.0.tgz) |
+
+
+-----
 ## Release [v1.31.12+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.31.12+rke2r1)
 <!-- v1.31.12+rke2r1 -->
 

--- a/docs/release-notes/v1.32.X.md
+++ b/docs/release-notes/v1.32.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 2
+sidebar_position: 3
 title: v1.32.X
 ---
 
@@ -11,6 +11,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.32.9+rke2r1](v1.32.X.md#release-v1329rke2r1) | Sep 18 2025| [v1.32.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1329) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.1.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.1.4-k3s2) | [v1.3.1](https://github.com/opencontainers/runc/releases/tag/v1.3.1) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | [v1.12.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.6-hardened1) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.3](https://github.com/flannel-io/flannel/releases/tag/v0.27.3)<br/>[Calico v3.30.3](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.3 ](https://docs.tigera.io/calico/latest/release-notes/#v3.30.3 ) | [v1.18.1](https://github.com/cilium/cilium/releases/tag/v1.18.1) | [v4.2.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2) |
 | [v1.32.8+rke2r1](v1.32.X.md#release-v1328rke2r1) | Aug 23 2025| [v1.32.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1328) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | [v1.12.4-hardened7](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.4-hardened7) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.2](https://github.com/flannel-io/flannel/releases/tag/v0.27.2)<br/>[Calico v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.18.0](https://github.com/cilium/cilium/releases/tag/v1.18.0) | [v4.2.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2) |
 | [v1.32.7+rke2r1](v1.32.X.md#release-v1327rke2r1) | Jul 25 2025| [v1.32.7](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1327) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2) | [v1.12.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.4-hardened2) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.1](https://github.com/flannel-io/flannel/releases/tag/v0.27.1)<br/>[Calico v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.17.6](https://github.com/cilium/cilium/releases/tag/v1.17.6) | [v4.2.1](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.1) |
 | [v1.32.6+rke2r1](v1.32.X.md#release-v1326rke2r1) | Jun 27 2025| [v1.32.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1326) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) | [v1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2) | [v1.12.2-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.2-hardened2) | [v0.16.11](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.11) | [Flannel v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0)<br/>[Calico v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.17.4](https://github.com/cilium/cilium/releases/tag/v1.17.4) | [v4.2.1](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.1) |
@@ -23,6 +24,56 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
+## Release [v1.32.9+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.32.9+rke2r1)
+<!-- v1.32.9+rke2r1 -->
+
+This release updates Kubernetes to v1.32.9.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.32.8+rke2r1:
+
+* Added Calico new images [(#8830)](https://github.com/rancher/rke2/pull/8830)
+* Added Cilium with wireguard e2e tests [(#8815)](https://github.com/rancher/rke2/pull/8815)
+* CNI and coredns bumps for Sep 25 release [(#8847)](https://github.com/rancher/rke2/pull/8847)
+* Bump k3s, containerd, runc [(#8866)](https://github.com/rancher/rke2/pull/8866)
+* Bump crictl and cloud provider [(#8863)](https://github.com/rancher/rke2/pull/8863)
+* Bump ingress-nginx v1.12.6-hardened1 [(#8870)](https://github.com/rancher/rke2/pull/8870)
+* Bump CNI chart latest version [(#8884)](https://github.com/rancher/rke2/pull/8884)
+* Update metrics-server chart 3.13.001 [(#8905)](https://github.com/rancher/rke2/pull/8905)
+* Update CoreDNS chart 1.43.302 [(#8909)](https://github.com/rancher/rke2/pull/8909)
+* Bump etcd [(#8911)](https://github.com/rancher/rke2/pull/8911)
+* Update to v1.32.9 and Go v1.23.12 [(#8917)](https://github.com/rancher/rke2/pull/8917)
+* Bump vsphere charts [(#8940)](https://github.com/rancher/rke2/pull/8940)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.18.103](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.18.103.tgz) |
+| rke2-canal | [v3.30.3-build2025090900](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.30.3-build2025090900.tgz) |
+| rke2-calico | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.30.300.tgz) |
+| rke2-calico-crd | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.30.300.tgz) |
+| rke2-coredns | [1.43.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.43.302.tgz) |
+| rke2-ingress-nginx | [4.12.600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.12.600.tgz) |
+| rke2-metrics-server | [3.13.001](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.001.tgz) |
+| rancher-vsphere-csi | [3.5.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.12.100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz) |
+| harvester-cloud-provider | [0.2.1000](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1000.tgz) |
+| harvester-csi-driver | [0.1.2400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2400.tgz) |
+| rke2-snapshot-controller | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.0.003.tgz) |
+| rke2-snapshot-controller-crd | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.0.003.tgz) |
+| rke2-snapshot-validation-webhook | [0.0.0](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-0.0.0.tgz) |
+
+
+-----
 ## Release [v1.32.8+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.32.8+rke2r1)
 <!-- v1.32.8+rke2r1 -->
 

--- a/docs/release-notes/v1.33.X.md
+++ b/docs/release-notes/v1.33.X.md
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-sidebar_position: 1
+sidebar_position: 2
 title: v1.33.X
 ---
 
@@ -11,6 +11,7 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.33.5+rke2r1](v1.33.X.md#release-v1335rke2r1) | Sep 18 2025| [v1.33.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1335) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.1.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.1.4-k3s2) | [v1.3.1](https://github.com/opencontainers/runc/releases/tag/v1.3.1) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | [v1.12.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.6-hardened1) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.3](https://github.com/flannel-io/flannel/releases/tag/v0.27.3)<br/>[Calico v3.30.3](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.3 ](https://docs.tigera.io/calico/latest/release-notes/#v3.30.3 ) | [v1.18.1](https://github.com/cilium/cilium/releases/tag/v1.18.1) | [v4.2.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2) |
 | [v1.33.4+rke2r1](v1.33.X.md#release-v1334rke2r1) | Aug 23 2025| [v1.33.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1334) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | [v1.12.4-hardened7](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.4-hardened7) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.2](https://github.com/flannel-io/flannel/releases/tag/v0.27.2)<br/>[Calico v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.18.0](https://github.com/cilium/cilium/releases/tag/v1.18.0) | [v4.2.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2) |
 | [v1.33.3+rke2r1](v1.33.X.md#release-v1333rke2r1) | Jul 25 2025| [v1.33.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1333) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2) | [v1.12.4-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.4-hardened2) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.1](https://github.com/flannel-io/flannel/releases/tag/v0.27.1)<br/>[Calico v3.30.2](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.17.6](https://github.com/cilium/cilium/releases/tag/v1.17.6) | [v4.2.1](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.1) |
 | [v1.33.2+rke2r1](v1.33.X.md#release-v1332rke2r1) | Jun 27 2025| [v1.33.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1332) | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) | [v2.0.5-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1) | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) | [v1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2) | [v1.12.2-hardened2](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.2-hardened2) | [v0.16.11](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.11) | [Flannel v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0)<br/>[Calico v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.1](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v1.17.4](https://github.com/cilium/cilium/releases/tag/v1.17.4) | [v4.2.1](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.1) |
@@ -19,6 +20,56 @@ Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent U
 
 <br />
 
+## Release [v1.33.5+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.33.5+rke2r1)
+<!-- v1.33.5+rke2r1 -->
+
+This release updates Kubernetes to v1.33.5.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.33.4+rke2r1:
+
+* Added Calico new images [(#8829)](https://github.com/rancher/rke2/pull/8829)
+* Added Cilium with wireguard e2e tests [(#8814)](https://github.com/rancher/rke2/pull/8814)
+* CNI and coredns bumps for Sep 25 release [(#8845)](https://github.com/rancher/rke2/pull/8845)
+* Bump k3s, containerd, runc [(#8865)](https://github.com/rancher/rke2/pull/8865)
+* Bump crictl and cloud provider [(#8862)](https://github.com/rancher/rke2/pull/8862)
+* Bump ingress-nginx v1.12.6-hardened1 [(#8869)](https://github.com/rancher/rke2/pull/8869)
+* Bump CNI chart latest version [(#8883)](https://github.com/rancher/rke2/pull/8883)
+* Update metrics-server chart 3.13.001 [(#8904)](https://github.com/rancher/rke2/pull/8904)
+* Update CoreDNS chart 1.43.302 [(#8908)](https://github.com/rancher/rke2/pull/8908)
+* Bump etcd [(#8912)](https://github.com/rancher/rke2/pull/8912)
+* Update to v1.33.5 and Go to v1.24.6 [(#8918)](https://github.com/rancher/rke2/pull/8918)
+* Bump vsphere charts [(#8939)](https://github.com/rancher/rke2/pull/8939)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.18.103](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.18.103.tgz) |
+| rke2-canal | [v3.30.3-build2025090900](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.30.3-build2025090900.tgz) |
+| rke2-calico | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.30.300.tgz) |
+| rke2-calico-crd | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.30.300.tgz) |
+| rke2-coredns | [1.43.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.43.302.tgz) |
+| rke2-ingress-nginx | [4.12.600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.12.600.tgz) |
+| rke2-metrics-server | [3.13.001](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.001.tgz) |
+| rancher-vsphere-csi | [3.5.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.12.100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz) |
+| harvester-cloud-provider | [0.2.1000](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1000.tgz) |
+| harvester-csi-driver | [0.1.2400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2400.tgz) |
+| rke2-snapshot-controller | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.0.003.tgz) |
+| rke2-snapshot-controller-crd | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.0.003.tgz) |
+| rke2-snapshot-validation-webhook | [0.0.0](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-0.0.0.tgz) |
+
+
+-----
 ## Release [v1.33.4+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.33.4+rke2r1)
 <!-- v1.33.4+rke2r1 -->
 

--- a/docs/release-notes/v1.34.X.md
+++ b/docs/release-notes/v1.34.X.md
@@ -1,0 +1,65 @@
+---
+hide_table_of_contents: true
+sidebar_position: 1
+title: v1.34.X
+---
+
+
+:::warning Upgrade Notice
+Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#urgent-upgrade-notes).
+:::
+
+| Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Canal (Default) | Calico | Cilium | Multus |
+| ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [v1.34.1+rke2r1](v1.34.X.md#release-v1341rke2r1) | Sep 17 2025| [v1.34.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1341) | [v3.6.4-k3s3](https://github.com/k3s-io/etcd/releases/tag/v3.6.4-k3s3) | [v2.1.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.1.4-k3s2) | [v1.3.1](https://github.com/opencontainers/runc/releases/tag/v1.3.1) | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | [v1.12.6-hardened1](https://github.com/rancher/ingress-nginx/releases/tag/v1.12.6-hardened1) | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) | [Flannel v0.27.3](https://github.com/flannel-io/flannel/releases/tag/v0.27.3)<br/>[Calico v3.30.3](https://docs.tigera.io/calico/latest/release-notes/#v3.30) | [v3.30.3 ](https://docs.tigera.io/calico/latest/release-notes/#v3.30.3 ) | [v1.18.1](https://github.com/cilium/cilium/releases/tag/v1.18.1) | [v4.2.2](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2) |
+
+<br />
+
+## Release [v1.34.1+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.34.1+rke2r1)
+<!-- v1.34.1+rke2r1 -->
+
+This release updates Kubernetes to v1.34.1.
+
+**Important Note**
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/rke2/server/token
+```
+
+### Changes since v1.33.4+rke2r1:
+
+* Bump aquasecurity/trivy-action from 0.32.0 to 0.33.0 [(#8841)](https://github.com/rancher/rke2/pull/8841)
+* Bump cni charts and coredns [(#8843)](https://github.com/rancher/rke2/pull/8843)
+* Update k8s to v1.34, go to v1.24.6 [(#8860)](https://github.com/rancher/rke2/pull/8860)
+* Bump ingress-nginx v1v1.30.14+rke2r4.12.6-hardened1 [(#8868)](https://github.com/rancher/rke2/pull/8868)
+* Bump CNI chart latest version [(#8887)](https://github.com/rancher/rke2/pull/8887)
+* Update metrics-server chart 3.13.001 [(#8903)](https://github.com/rancher/rke2/pull/8903)
+* Update CoreDNS chart 1.43.302 [(#8907)](https://github.com/rancher/rke2/pull/8907)
+* Update to v1.34.1 and Go v1.24.6 [(#8919)](https://github.com/rancher/rke2/pull/8919)
+* Remove cloud-config arg from kubelet [(#8927)](https://github.com/rancher/rke2/pull/8927)
+* Bump vsphere cpi chart [(#8938)](https://github.com/rancher/rke2/pull/8938)
+
+
+## Charts Versions
+| Component | Version |
+| --- | --- |
+| rke2-cilium | [1.18.103](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.18.103.tgz) |
+| rke2-canal | [v3.30.3-build2025090900](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.30.3-build2025090900.tgz) |
+| rke2-calico | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.30.300.tgz) |
+| rke2-calico-crd | [v3.30.300](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.30.300.tgz) |
+| rke2-coredns | [1.43.302](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.43.302.tgz) |
+| rke2-ingress-nginx | [4.12.600](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.12.600.tgz) |
+| rke2-metrics-server | [3.13.001](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.001.tgz) |
+| rancher-vsphere-csi | [3.5.0-rancher100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher100.tgz) |
+| rancher-vsphere-cpi | [1.12.100](https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz) |
+| harvester-cloud-provider | [0.2.1000](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1000.tgz) |
+| harvester-csi-driver | [0.1.2400](https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2400.tgz) |
+| rke2-snapshot-controller | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.0.003.tgz) |
+| rke2-snapshot-controller-crd | [4.0.003](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.0.003.tgz) |
+| rke2-snapshot-validation-webhook | [0.0.0](https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-validation-webhook/rke2-snapshot-validation-webhook-0.0.0.tgz) |
+
+
+-----

--- a/scripts/collect-all-release-notes.sh
+++ b/scripts/collect-all-release-notes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MINORS=${MINORS:-"v1.30 v1.31 v1.32 v1.33"}
+MINORS=${MINORS:-"v1.31 v1.32 v1.33 v1.34"}
 
 function gen_md_link()
 {
@@ -118,7 +118,7 @@ for file in $(ls -r docs/release-notes/v1.*.X.md); do
 done
 
 ITER=1
-echo "Reordering release notes in sidebar"
+echo "Reordering older release notes in sidebar"
 for file in $(ls -r docs/release-notes-old/v1.*.X.md); do
     sed -i "s/^sidebar_position:.*/sidebar_position: $ITER/" "${file}"
     ITER=$((ITER+1))


### PR DESCRIPTION
- Remove browserlist update from collect release notes, run as independent cron job 
- Bump setup-node to v5, ensure node 22+ is used
- Move v1.29 to older release notes section