### PR TITLE
Be more specific on ports for ICMP

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -139,12 +139,12 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | Port        | Protocol  | Source            | Destination       | Description
 |-------------|-----------|-------------------|-------------------|------------
-| 8/0 *       | ICMP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
+| 0, 8 *       | ICMP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
 | 4240        | TCP       | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
 | 8472        | UDP       | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with VXLAN
 | 51871       | UDP       | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with WireGuard
 
-\* 8/0 is not a port but the [ICMP type](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types). It is required for the network utility ping
+\* 0, 8 is not a port but the [ICMP type](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types). It is required for the network utility ping
 
 </TabItem>
 <TabItem value="Calico">

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -137,12 +137,14 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 </TabItem>
 <TabItem value="Cilium">
 
-| Port        | Protocol | Source            | Destination       | Description
-|-------------|----------|-------------------|-------------------|------------
-| 8/0         | ICMP     | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
-| 4240        | TCP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
-| 8472        | UDP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with VXLAN
-| 51871       | UDP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with WireGuard
+| Port        | Protocol  | Source            | Destination       | Description
+|-------------|-----------|-------------------|-------------------|------------
+| 8/0 *       | ICMP      | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
+| 4240        | TCP       | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI health checks
+| 8472        | UDP       | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with VXLAN
+| 51871       | UDP       | All RKE2 nodes    | All RKE2 nodes    | Cilium CNI with WireGuard
+
+\* 8/0 is not a port but the [ICMP type](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types). It is required for the network utility ping
 
 </TabItem>
 <TabItem value="Calico">


### PR DESCRIPTION
A colleague got confused when configuring the AWS Security groups because 0/8 ports were not possible. I can see how the current docs could confuse users who are not familiar with the networking stack. This PR clarifies that ICMP has no port:

<img width="675" height="331" alt="image" src="https://github.com/user-attachments/assets/553f0d1e-5580-47d0-8935-17058c1cc071" />

