### PR TITLE
docs: Fix Release Note table too wide

### DIFF
--- a/scripts/collect-all-release-notes.sh
+++ b/scripts/collect-all-release-notes.sh
@@ -75,7 +75,9 @@ function process_minor() {
             echo -e "${title}" >> $global_table
             upgrade_link="[Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-${minor:1}.md#urgent-upgrade-notes)"
             upgrade_warning=":::warning Upgrade Notice\nBefore upgrading from earlier releases, be sure to read the Kubernetes ${upgrade_link}.\n:::\n"
+            wide_container_table="<div className=\"wide-table-container\">"
             echo -e "${upgrade_warning}" >> $global_table
+            echo -e "${wide_container_table}\n" >> $global_table
             echo -n "| Version | Release date " >> $global_table
             # RKE2 Core Components
             echo "$body"  | grep "^|" | tail +3 | head -9 | awk -F'|' '{ print $2 }' | while read column; do echo -n "| $column " >> $global_table; done
@@ -95,7 +97,7 @@ function process_minor() {
         # Wrap Important Notes in a Warning block
         perl -i -p0e 's/\*\*Important Notes\*\*(.*?)###/:::warning Important Notes\n$1\n:::\n\n###/s' "${file}"
     done
-    echo -e "\n<br />\n" >> $global_table
+    echo -e "\n</div>\n\n<br />\n" >> $global_table
     # Append the global component and version table
     rke2tmp=$(mktemp)
     cat $global_table "${file}" > $rke2tmp && mv $rke2tmp "${file}"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -46,6 +46,8 @@
   --ifm-color-primary-darker: #2b83bc;
   --ifm-color-primary-darkest: #236c9b;
   --ifm-code-font-size: 95%;
+  --ifm-container-width-xl: 1600px;
+  --ifm-container-width: 1400px;
   --label-color: #d5d5d5ff;
 }
 
@@ -100,4 +102,16 @@ hr {
   .navbar-sidebar__back {
     display: none;
   }
+}
+
+.wide-table-container table {
+  display: table;
+  width: 100%;
+}
+
+.wide-table-container table th,
+.wide-table-container table td {
+  word-break: normal;
+  overflow-wrap: break-word;
+  white-space: normal;
 }


### PR DESCRIPTION
Fixes #525 and https://github.com/rancher/rke2-docs/pull/512#issuecomment-4355498654.

<img width="1716" height="1360" alt="image" src="https://github.com/user-attachments/assets/b5bfb2a0-7332-4d3b-97dd-068443020b0a" />
