### PR TITLE
Update Traefik Gateway API version

### DIFF
--- a/docs/networking/networking_services.md
+++ b/docs/networking/networking_services.md
@@ -188,14 +188,16 @@ spec:
         enabled: true
 #       experimentalChannel: true (read warning below)
 ```
-Traefik is compatible with [Gateway API v1.4](https://gateway-api.sigs.k8s.io/reference/1.4/spec/).
+Traefik v3.6.x is compatible with [Gateway API v1.4](https://gateway-api.sigs.k8s.io/reference/1.4/spec/).
+
+Traefik v3.7.x is compatible with [Gateway API v1.5](https://gateway-api.sigs.k8s.io/reference/1.5/spec/).
 
 :::warning Gateway API resources
 Prior to the April 2026 releases (v1.33.11+rke2r1, v1.34.7+rke2r1 and v1.35.4+rke2r1), Gateway API CRDs are removed if traefik is disabled after previously having been enabled. When using an affected release, avoid disabling traefik or uninstalling the traefik-crds AddOn if your cluster contains Gateway API resources that you do not want removed.
 :::
 
 :::warning
-If you need support for experimental Gateway API resources, e.g. TCPRoute, you must install the [v1.4 experimental-install.yaml](https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml) from the official [gateway-api releases](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.4.0) and use the option `providers.kubernetesGateway.experimentalChannel=true` in the rke2-traefik chart values.
+If you need support for experimental Gateway API resources, you must install them separately. For example, for Gateway API v1.4, install the [v1.4 experimental-install.yaml](https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml) from the official [gateway-api releases](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.4.0) and use the option `providers.kubernetesGateway.experimentalChannel=true` in the rke2-traefik chart values.
 :::
 
 

--- a/docs/networking/networking_services.md
+++ b/docs/networking/networking_services.md
@@ -188,9 +188,9 @@ spec:
         enabled: true
 #       experimentalChannel: true (read warning below)
 ```
-Traefik v3.6.x is compatible with [Gateway API v1.4](https://gateway-api.sigs.k8s.io/reference/1.4/spec/).
+* Traefik v3.7.x is compatible with [Gateway API v1.5](https://gateway-api.sigs.k8s.io/reference/1.5/spec/).
+* Traefik v3.6.x is compatible with [Gateway API v1.4](https://gateway-api.sigs.k8s.io/reference/1.4/spec/).
 
-Traefik v3.7.x is compatible with [Gateway API v1.5](https://gateway-api.sigs.k8s.io/reference/1.5/spec/).
 
 :::warning Gateway API resources
 Prior to the April 2026 releases (v1.33.11+rke2r1, v1.34.7+rke2r1 and v1.35.4+rke2r1), Gateway API CRDs are removed if traefik is disabled after previously having been enabled. When using an affected release, avoid disabling traefik or uninstalling the traefik-crds AddOn if your cluster contains Gateway API resources that you do not want removed.


### PR DESCRIPTION
The new release of RKE2 brings a new version of Gateway API