### PR TITLE
docs: document acceptable values for server/agent config options

### DIFF
--- a/docs/reference/linux_agent_config.md
+++ b/docs/reference/linux_agent_config.md
@@ -4,11 +4,27 @@ title: Agent Configuration Reference
 
 This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the [configuration file](../install/configuration.md#configuration-file).
 
+### Configuration value types
+
+Parameters can be set via CLI flags, the [configuration file](../install/configuration.md#configuration-file), or environment variables (when listed in the tables below).
+
+**Boolean options** have a default of `true` or `false` (for example `debug` / `RKE2_DEBUG`):
+
+| Method | Acceptable values | Example |
+| --- | --- | --- |
+| Config file | `true` or `false` | `debug: true` |
+| CLI | Flag presence enables the option; optional explicit value | `--debug`, `--debug=true`, or `--debug=false` |
+| Environment variable | Boolean strings accepted by Go's `strconv.ParseBool`: `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False` | `RKE2_DEBUG=true` |
+
+**Enumerated options** list their acceptable values in the Description column (wording such as "one of", "valid items", or "valid values").
+
+**Other string and list options** accept free-form values as described. List options may be repeated on the CLI or written as YAML lists in the config file (see the [configuration file](../install/configuration.md#configuration-file) docs).
+
 ## Common
 | Flag | Description | Default | Environment Variable |
 | --- | --- | --- | --- |
 | config | Path to config file | /etc/rancher/rke2/config.yaml | RKE2_CONFIG_FILE |
-| debug | Turn on debug logs  | false | RKE2_DEBUG |
+| debug | Turn on debug logs (boolean: `true` or `false`)  | false | RKE2_DEBUG |
 | data-dir | Folder to hold state  | "/var/lib/rancher/rke2" | RKE2_DATA_DIR |
 ## Cluster
 | Flag | Description | Environment Variable |

--- a/docs/reference/server_config.md
+++ b/docs/reference/server_config.md
@@ -4,6 +4,22 @@ title: Server Configuration Reference
 
 This is a reference to all parameters that can be used to configure the rke2 server. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the [configuration file](../install/configuration.md#configuration-file).
 
+### Configuration value types
+
+Parameters can be set via CLI flags, the [configuration file](../install/configuration.md#configuration-file), or environment variables (when listed in the tables below).
+
+**Boolean options** have a default of `true` or `false` (for example `debug` / `RKE2_DEBUG`):
+
+| Method | Acceptable values | Example |
+| --- | --- | --- |
+| Config file | `true` or `false` | `debug: true` |
+| CLI | Flag presence enables the option; optional explicit value | `--debug`, `--debug=true`, or `--debug=false` |
+| Environment variable | Boolean strings accepted by Go's `strconv.ParseBool`: `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False` | `RKE2_DEBUG=true` |
+
+**Enumerated options** list their acceptable values in the Description column (wording such as "one of", "valid items", or "valid values"). Examples include `cni`, `egress-selector-mode`, `ingress-controller`, `profile`, and `secrets-encryption-provider`.
+
+**Other string and list options** accept free-form values as described. List options may be repeated on the CLI or written as YAML lists in the config file (see the [configuration file](../install/configuration.md#configuration-file) docs).
+
 ### Critical Configuration Values
 
 The following options must be set to the same value on all servers in the cluster. Failure to do so will cause new servers to fail to join the cluster.
@@ -22,7 +38,7 @@ The following options must be set to the same value on all servers in the cluste
 | Flag | Description | Default | Environment Variable |
 | --- | --- | --- | --- |
 | config | Path to config file | /etc/rancher/rke2/config.yaml | RKE2_CONFIG_FILE |
-| debug | Turn on debug logs  | false | RKE2_DEBUG |
+| debug | Turn on debug logs (boolean: `true` or `false`)  | false | RKE2_DEBUG |
 | data-dir | Folder to hold state  | "/var/lib/rancher/rke2" | RKE2_DATA_DIR |
 ### Listener
 | Flag | Description | Default |

--- a/docs/reference/windows_agent_config.md
+++ b/docs/reference/windows_agent_config.md
@@ -6,6 +6,20 @@ This is a reference to all parameters that can be used to configure the Windows 
 
 **Windows Support requires choosing Calico or Flannel as the CNI for the RKE2 cluster**
 
+### Configuration value types
+
+Parameters can be set via CLI flags, the [configuration file](../install/configuration.md#configuration-file), or environment variables (when shown in brackets, for example `[%RKE2_DEBUG%]`).
+
+**Boolean options** appear in CLI help without a trailing `value` (for example `--debug`). Acceptable values:
+
+| Method | Acceptable values | Example |
+| --- | --- | --- |
+| Config file | `true` or `false` | `debug: true` |
+| CLI | Flag presence enables the option; optional explicit value | `--debug`, `--debug=true`, or `--debug=false` |
+| Environment variable | Boolean strings accepted by Go's `strconv.ParseBool`: `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False` | `RKE2_DEBUG=true` |
+
+Options that take a free-form string show `value` after the flag name in the help text below (for example `--token value`).
+
 ## Windows RKE2 Agent CLI Help
 
 ```console


### PR DESCRIPTION
## Summary

The RKE2 server (and agent) configuration reference listed flags such as `debug` / `RKE2_DEBUG` with a default of `false`, but did not document which values are acceptable when enabling the option via config file, CLI, or environment variable.

This change:

- Adds a **Configuration value types** section to the server, Linux agent, and Windows agent config references
- Documents acceptable values for **boolean** options (config `true`/`false`, CLI `--flag` / `--flag=true|false`, env vars via Go `strconv.ParseBool`)
- Points readers to description text for **enumerated** options (`one of` / `valid items` / `valid values`)
- Updates the `debug` description to state it is a boolean (`true` or `false`)

## Issue

Fixes rancher/rancher#52889

The docs live in this repo (`docs.rke2.io`), not `rancher/rancher`.

## Test plan

- [x] Review rendered tables for server and agent config pages
- [x] Confirm examples match urfave/cli BoolFlag / Go `strconv.ParseBool` behavior